### PR TITLE
fix: update flatted to patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
# Introduction :pencil2:

Updates a transitive dependency (`flatted`) from **3.3.4 → 3.4.2** via `flat-cache` (used by `cspell`) to address a high-severity vulnerability.

Resolves advisory **GHSA-25h7-pfq9-p65f** (unbounded recursion DoS in `flatted.parse()`).

This is a **lockfile-only change** with no modifications to application or source code.

---

## Resolution :heavy_check_mark:

* Updated `flatted` dependency to **v3.4.2** in `package-lock.json`
* Resolved vulnerability **GHSA-25h7-pfq9-p65f**
* Verified dependency tree:

  * `npm ls flatted` resolves to `flatted@3.4.2`
* Verified security status:

  * `npm audit --json` reports **0 vulnerabilities** and no `flatted` advisory

---

## Miscellaneous :heavy_plus_sign:

* No functional or runtime changes
* `npm run validate:all` still fails due to **pre-existing markdownlint/cspell issues** in imported `docs/` content (unrelated to this change)

---

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

<!-- Add screenshots here if needed -->

</details>

---

**Risk / Impact**

* Low risk: lockfile-only update (**3 lines added, 3 lines removed**)
* No expected impact on application behaviour or runtime execution

---
