### PR TITLE
feat: add issue template config to enable template visibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []


### PR DESCRIPTION
# Introduction :pencil2:

This PR adds the missing `config.yml` file to the issue templates directory, which is required for GitHub to properly display issue forms in the repository's issue creation UI. Without this configuration file, the ticket template does not appear as an option when creating new issues.

## Resolution :heavy_check_mark:

- Created `.github/ISSUE_TEMPLATE/config.yml` with basic configuration
- Set `blank_issues_enabled: true` to allow users to choose between the template or blank issues
- Set `contact_links: []` (empty array) for future contact link additions if needed

## Miscellaneous :heavy_plus_sign:

- **Why this was needed**: GitHub's issue forms feature requires a `config.yml` file to be present in the `.github/ISSUE_TEMPLATE/` directory for templates to appear in the UI. The ticket template YAML file was merged in PR #[previous PR number] but wasn't showing up because this configuration file was missing.
- **User experience improvement**: Users will now see "🎟️ Ticket Template" as a clear option when clicking "New Issue" on the repository, alongside the option to open a blank issue.
- **Future extensibility**: The `contact_links` array can be populated later to add external support channels or documentation links if required.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

_Screenshots to be added after merge showing:_
- New issue creation page with "