### PR TITLE
fix: remove empty title field from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ticket-template.yml
+++ b/.github/ISSUE_TEMPLATE/ticket-template.yml
@@ -1,10 +1,18 @@
 name: "🎟️ Ticket Template"
 description: "🛠️ Agreed standard template for creating tickets"
-title: ""
 labels: []
 assignees: []
 
 body:
+  - type: input
+    id: title
+    attributes:
+      label: "📝 Issue Title"
+      description: Enter a brief, descriptive title for this issue
+      placeholder: "e.g., Add user authentication to portal"
+    validations:
+      required: true
+
   - type: dropdown
     id: team
     attributes:


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes the issue template visibility problem by removing the invalid empty title field and adding a user-editable title input field. The empty `title: ""` field was preventing the ticket template from appearing in GitHub's issue creation UI. This change ensures the template is properly displayed and allows users to enter custom issue titles.

## Resolution :heavy_check_mark:

- Removed invalid `title: ""` field from template YAML that was causing GitHub to reject the template
- Added new `input` type field for issue title as the first field in the form:
  - Field ID: `title`
  - Label: "📝 Issue Title"
  - Description: "Enter a brief, descriptive title for this issue"
  - Placeholder: "e.g., Add user authentication to portal"
  - Validation: Required field
- Ensures proper template rendering in GitHub UI at `/issues/new/choose`

## Miscellaneous :heavy_plus_sign:

- **Root cause**: GitHub issue forms do not accept empty string values (`""`) for the title field in the YAML frontmatter. This causes the entire template to be rejected and not displayed in the UI.
- **Solution rationale**: Instead of leaving title unspecified, we provide a dedicated input field for users to enter a meaningful title, improving the issue creation UX.
- **Field ordering**: The title field appears first (before Team and Estimation) as it's the most fundamental piece of information for an issue.
- **User experience**: Users will now see the template in the issue chooser and can customise the issue title directly in the form.


## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>
- Issue template selection page with "🎟️ Ticket Template" visible
- Template form with the new title input field at the top
- Filled example showing: Title → Team → Estimation → Ticket Details flow

</details>