### PR TITLE
Fix incomplete string escaping vulnerability by escaping backslashes before quotes

### DIFF
--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -369,8 +369,10 @@ function buildFrontmatter(obj) {
     if (value === null || value === undefined) continue;
     if (typeof value === 'string') {
       // Quote strings that contain special chars
-      if (value.includes(':') || value.includes('#') || value.includes('"')) {
-        result += `${key}: "${value.replace(/"/g, '\\"')}"\n`;
+      if (value.includes(':') || value.includes('#') || value.includes('"') || value.includes('\\')) {
+        // Escape backslashes first, then double quotes to prevent incomplete escaping
+        const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        result += `${key}: "${escaped}"\n`;
       } else {
         result += `${key}: ${value}\n`;
       }


### PR DESCRIPTION

# Introduction :pencil2:

Fixes CodeQL security alert #21 (js/incomplete-sanitization) by correcting incomplete string escaping in the YAML frontmatter builder function.

The previous implementation only escaped double quotes when sanitizing strings for YAML frontmatter, but failed to escape backslashes first. This could lead to incomplete escaping where a backslash before a quote would escape the escaped quote, leaving an unescaped quote in the output.

## Resolution :heavy_check_mark:

- **Escape backslashes before quotes**: Modified `buildFrontmatter()` in ingest.mjs to escape backslashes (`\`) before escaping double quotes (`"`), preventing injection vulnerabilities
- **Updated condition check**: Added backslash detection to the condition that determines if a string needs quoting and escaping
- **Correct escaping order**: Changed from `value.replace(/"/g, '\\"')` to `value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')` to ensure complete sanitization

**Example of the fix:**
- **Before**: Input `hello\"world` → Output `"hello\"world"` (incomplete escaping, quote exposed)
- **After**: Input `hello\"world` → Output `"hello\\"world"` (complete escaping, both backslash and quote properly escaped)

## Miscellaneous :heavy_plus_sign:

- Added inline comment explaining the escaping order to prevent future regressions
- This fix follows OWASP and CodeQL best practices for sanitization

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

N/A - This is a security fix with no visual changes.

</details>