### PR TITLE
Use NODE_VERSION repo variable in deploy and preview workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.1.0
         with:
-          node-version: 22
+          node-version: ${{ vars.NODE_VERSION }} # Set in repo variables (Settings > Secrets and variables > Actions)
           cache: npm
 
       - name: SLSA supply chain protection

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.1.0
         with:
-          node-version: 22
+          node-version: ${{ vars.NODE_VERSION }} # Set in repo variables (Settings > Secrets and variables > Actions)
           cache: npm
 
       - name: SLSA supply chain protection


### PR DESCRIPTION
## Summary
This PR replaces hardcoded Node.js versions in GitHub Actions workflows with the repository variable NODE_VERSION.

## What changed
Updated deploy.yml:43 to use vars.NODE_VERSION.
Updated preview.yml:20 to use vars.NODE_VERSION.
Added inline comments indicating where NODE_VERSION is configured in GitHub Actions Variables.

## Why
Keeps Node version configuration centralised.
Prevents version drift across workflows.
Makes future Node upgrades a one-place change in repo settings.

## Validation
Commit hooks passed:
Security scan (gitleaks): passed
Lint check: passed
Spell check: passed