### PR TITLE
feat: add contact us page and code formatter

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "run"
+}

--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { Breadcrumbs } from '@/components/Breadcrumbs';
+import { ChatBot } from '@/components/ChatBot';
+import contactOptions from '@/content/contact/contacts.json';
+import { PageIntro } from '@/components/templateRender/PageIntro';
+
+type ContactOption = {
+  slug: string;
+  title: string;
+  description: string;
+  linkText: string;
+  href: string;
+  cssModifier?: string;
+  isCopyOnly?: boolean;
+};
+
+type ContactPageData = {
+  title: string;
+  summary: string;
+  items: ContactOption[];
+};
+
+export default function ContactPage() {
+  const contact = contactOptions as ContactPageData;
+
+  return (
+    <div className="govuk-width-container">
+      <Breadcrumbs items={[{ label: 'Contact us' }]} />
+
+      <PageIntro
+        title={contactOptions.title}
+        summary={contactOptions.summary}
+        summaryClassName="govuk-body-l"
+      />
+
+      {contact.items.map((item) => (
+        <section
+          key={item.slug}
+          className={`app-phase-card ${item.cssModifier ? `app-phase-card--${item.cssModifier}` : ''}`}
+        >
+          <h2 className="govuk-heading-m govuk-!-margin-bottom-2">{item.title}</h2>
+
+          <p className="govuk-body">{item.description}</p>
+
+          {item.isCopyOnly ? (
+            <p className="govuk-body govuk-!-margin-top-2">
+              <strong>Email:</strong> <>{item.linkText}</>
+            </p>
+          ) : (
+            <a
+              href={item.href}
+              className="govuk-link govuk-link--no-visited-state"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {item.linkText}
+              <span className="govuk-visually-hidden"> (opens in a new tab) </span>
+            </a>
+          )}
+        </section>
+      ))}
+
+      <ChatBot />
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { href: '/guidelines', label: 'Guidelines' },
   { href: '/docs', label: 'Documentation' },
   { href: '/community', label: 'Community' },
+  { href: '/contact-us', label: 'Contact us'}
 ];
 
 export function Header() {

--- a/content/contact/contacts.json
+++ b/content/contact/contacts.json
@@ -1,0 +1,31 @@
+{
+  "title": "Contact Us",
+  "summary": "You can contact the team in the following ways:",
+  "items":
+  [
+    {
+      "slug": "slack",
+      "title": "Slack",
+      "description": "Use Slack for quick questions, informal support, and conversations with the team.",
+      "linkText": "Open Slack channel",
+      "href": "https://moj.enterprise.slack.com/archives/C0AJBK3P5A8",
+      "cssModifier": "blue"
+    },
+    {
+      "slug": "email",
+      "title": "Email",
+      "description": "Send us an email for general enquiries.",
+      "linkText": "email here",
+      "href": "mailto:email",
+      "cssModifier": "green",
+      "isCopyOnly": true
+    },
+    {
+      "slug": "github-discussions",
+      "title": "GitHub discussions",
+      "description": "Use GitHub Discussions for technical questions and feature requests.",
+      "linkText": "Open GitHub Discussions",
+      "href": "https://github.com/ministryofjustice/ministry-of-justice-developer-portal/discussions",
+      "cssModifier": "purple"
+    }
+  ]}

--- a/content/contact/contacts.json
+++ b/content/contact/contacts.json
@@ -15,7 +15,7 @@
       "slug": "email",
       "title": "Email",
       "description": "Send us an email for general enquiries.",
-      "linkText": "email here",
+      "linkText": "DeveloperExperienceTeam@justice.gov.uk",
       "href": "mailto:DeveloperExperienceTeam@justice.gov.uk",
       "cssModifier": "green",
       "isCopyOnly": true

--- a/content/contact/contacts.json
+++ b/content/contact/contacts.json
@@ -16,7 +16,7 @@
       "title": "Email",
       "description": "Send us an email for general enquiries.",
       "linkText": "email here",
-      "href": "mailto:email",
+      "href": "mailto:DeveloperExperienceTeam@justice.gov.uk",
       "cssModifier": "green",
       "isCopyOnly": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "cspell": "^9.7.0",
         "markdownlint-cli": "^0.48.0",
         "pagefind": "^1.4.0",
+        "prettier": "^3.8.1",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -3755,6 +3756,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/property-information": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cspell": "^9.7.0",
     "markdownlint-cli": "^0.48.0",
     "pagefind": "^1.4.0",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3"
   },
   "engines": {


### PR DESCRIPTION
# Introduction :pencil2:

Added a "contact us" page to the developer portal which links to our Slack channel (devx-nudge-group), placeholder for team email, and a link to our GitHub Discussions.

I've also added Prettier code formatter + config for standardisation.

## Resolution :heavy_check_mark:
Expanded navigation to include contact page.
Added contact page.

PENDING: adding the email (once created)

## Miscellaneous :heavy_plus_sign:

Included Prettier

## Screenshot(s) :camera_flash:

<img width="1121" height="925" alt="Screenshot 2026-04-09 at 18 45 30" src="https://github.com/user-attachments/assets/7c01e1ad-9b3b-42ba-ba05-d36ee609b049" />

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>