### PR TITLE
Add security guidance docs source

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -35,6 +35,17 @@
       "format": "tech-docs-template",
       "owner_slack": "#analytical-platform",
       "enabled": true
+    },
+    {
+      "id": "security-guidance",
+      "name": "Cyber and Technical Security Guidance",
+      "description": "Ministry of Justice cyber and technical security guidance.",
+      "category": "security",
+      "repo": "ministryofjustice/security-guidance",
+      "branch": "main",
+      "docsPath": "docs",
+      "format": "markdown",
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
This PR adds Security Guidance as a new ingested documentation section in the Developer Portal.

## What Changed ##

```
Added a new source entry in sources.json:
id: security-guidance
name: Cyber and Technical Security Guidance
repo: ministryofjustice/security-guidance
branch: main
docsPath: docs
category: security
format: markdown
enabled: true
```

## Why ##
The Security Guidance content is currently hosted in: https://github.com/ministryofjustice/security-guidance/tree/main/docs
Adding this source allows the portal ingestion pipeline to include it as a first-class documentation section.

## Validation ##
Local targeted ingest completed successfully for security-guidance.
Local build/type checks passed during verification.
New docs source folder was generated locally under content/docs/security-guidance during test ingestion.