### PR TITLE
Align ECR secrets and add deploy preflight checks

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,10 +29,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Validate ECR configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ secrets.DEV_ECR_ROLE_TO_ASSUME }}" ]]; then
+            echo "Missing required secret: DEV_ECR_ROLE_TO_ASSUME"
+            exit 1
+          fi
+          if [[ -z "${{ vars.ECR_REGION }}" ]]; then
+            echo "Missing required variable: ECR_REGION"
+            exit 1
+          fi
+          if [[ -z "${{ vars.ECR_REPOSITORY }}" ]]; then
+            echo "Missing required variable: ECR_REPOSITORY"
+            exit 1
+          fi
+
       - name: Configure AWS credentials for ECR
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.DEV_ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ECR_REGION }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,6 +25,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Validate ECR configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ secrets.PROD_ECR_ROLE_TO_ASSUME }}" ]]; then
+            echo "Missing required secret: PROD_ECR_ROLE_TO_ASSUME"
+            exit 1
+          fi
+          if [[ -z "${{ vars.ECR_REGION }}" ]]; then
+            echo "Missing required variable: ECR_REGION"
+            exit 1
+          fi
+          if [[ -z "${{ vars.ECR_REPOSITORY }}" ]]; then
+            echo "Missing required variable: ECR_REPOSITORY"
+            exit 1
+          fi
+
       - name: Configure AWS credentials for ECR
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:


### PR DESCRIPTION
This PR fixes deploy workflow AWS auth setup.

Dev now uses the correct secret name: DEV_ECR_ROLE_TO_ASSUME

Dev and Prod now include a preflight check for required values:
role secret
ECR_REGION
ECR_REPOSITORY

## Result

clearer failures and more reliable deploys when secrets/variables are missing.