### PR TITLE
feat: Add cooldown to dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,27 +11,62 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
This pull request updates the Dependabot configuration to introduce cooldown periods for updates across all supported package ecosystems. These cooldowns control how frequently Dependabot will create new pull requests for different types of version updates, helping to reduce noise and manage update frequency.

Key changes to `.github/dependabot.yml`:

* Added a `cooldown` configuration for each package ecosystem, specifying:
  * No cooldown for new updates by default (`default-days: 0`)
  * 14-day cooldown for major version updates (`semver-major-days: 14`)
  * 7-day cooldown for minor version updates (`semver-minor-days: 7`)
  * 3-day cooldown for patch version updates (`semver-patch-days: 3`)