### PR TITLE
Fix/fix dependabot default cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,27 +11,62 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 0
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 0
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
@@ -30,7 +30,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 0
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
@@ -39,7 +39,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 0
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
@@ -48,7 +48,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 0
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
@@ -57,7 +57,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 0
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
@@ -66,7 +66,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 0
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,18 +22,12 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 3
-      semver-major-days: 8
-      semver-minor-days: 4
-      semver-patch-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
       default-days: 3
-      semver-major-days: 8
-      semver-minor-days: 4
-      semver-patch-days: 3
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -67,6 +61,3 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 3
-      semver-major-days: 8
-      semver-minor-days: 4
-      semver-patch-days: 3

--- a/content/guidelines/dependabot-guidelines.mdx
+++ b/content/guidelines/dependabot-guidelines.mdx
@@ -34,7 +34,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 0
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3


### PR DESCRIPTION
This pull request updates the Dependabot configuration and its related documentation to increase the default cooldown period for dependency update PRs. The main goal is to reduce the frequency of update pull requests, making them more manageable for maintainers.

**Dependabot configuration changes:**

* Increased the `default-days` cooldown from 0 to 3 days for all package ecosystems in `.github/dependabot.yml`, which will slow down the frequency of PRs for new dependency updates. Cooldown periods for major and minor updates have also been reduced, making them appear sooner after the default cooldown.

**Documentation update:**

* Updated the example configuration in `content/guidelines/dependabot-guidelines.mdx` to reflect the new `default-days: 3` cooldown, ensuring documentation matches the actual configuration.