### PR TITLE
feat: add source for octo strategic docs

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -43,9 +43,21 @@
     "kubeconfig",
     "kdev",
     "kprod",
-    "webp"
+    "webp",
+    "octo",
+    "OCTO"
   ],
-  "dictionaries": ["en-gb", "companies", "softwareTerms", "misc", "lorem-ipsum", "typescript", "node", "bash", "npm"],
+  "dictionaries": [
+    "en-gb",
+    "companies",
+    "softwareTerms",
+    "misc",
+    "lorem-ipsum",
+    "typescript",
+    "node",
+    "bash",
+    "npm"
+  ],
   "languageSettings": [
     {
       "languageId": "commit-msg",

--- a/sources.json
+++ b/sources.json
@@ -57,6 +57,17 @@
       "docsPath": "source/documentation",
       "format": "tech-docs-template",
       "enabled": true
+    },
+    {
+      "id": "octo-strategic-docs",
+      "name": "OCTO Strategic Documentation",
+      "description": "Documentation source for OCTO Strategic Documentation.",
+      "category": "documentation",
+      "repo": "ministryofjustice/octo-strategic-docs",
+      "branch": "main",
+      "docsPath": "source",
+      "format": "tech-docs-template",
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
# Introduction :pencil2:

Added the OCTO Strategic documentation to the registry.

## Resolution :heavy_check_mark:

Amended sources.json with relevant details to ingest the required docs
Updated spell check library to include OCTO and octo.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>