### PR TITLE
feat(seo): add interim robots policy note

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,12 @@ Set these in GitHub Actions variables at repository level, or as environment var
 - [Cloud Platform deployment runbook](docs/runbooks/cloud-platform-deployment-runbook.md)
 - [Documentation ingestion runbook](docs/runbooks/ingestion-runbook.md)
 
+#### Search Indexing (Interim)
+
+- `public/robots.txt` contains temporary crawler guidance for Issue #299.
+- Core pages remain indexable; high-risk/utility paths are disallowed (`/search`, `/api/`, `/_next/`, and parameterized URLs via `/*?*`).
+- Rules are intended to be reviewed after automated refresh work in Issue #281 is complete.
+
 #### Runtime hardening
 
 Both Kubernetes deployments apply a baseline container hardening profile:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,20 @@
+# Interim indexing controls for Issue #299.
+# This is a temporary mitigation until automated refresh in Issue #281 is complete.
+
+User-agent: *
+
+# Keep core portal content indexable.
+Allow: /
+Allow: /docs/
+Allow: /guidelines/
+Allow: /products/
+Allow: /community/
+
+# Reduce indexing risk for high-churn or non-canonical sections.
+Disallow: /docs/docsify-test-site/
+Disallow: /search
+Disallow: /api/
+Disallow: /_next/
+
+# Avoid indexing search-like parameterized URLs.
+Disallow: /*?*


### PR DESCRIPTION
Adds a top-level robots.txt to provide temporary crawler guidance while content refresh automation (Issue #281) is being implemented.

## Why
The portal has started ranking above canonical platform documentation in search results, which risks directing users to potentially stale content. This is a low-risk, easily reversible mitigation.

## Changes

- robots.txt — new file with interim crawler directives
- README.md — brief note added under a new Search Indexing (Interim) section
- Allow	/, docs, /guidelines/, /products/, /community/	Core portal content stays discoverable
- Disallow	/search	Low-value search result pages
- Disallow	/api/, /_next/	Internal/utility paths
- Disallow	/*?*	Parameterized/duplicate URLs

## Testing
 curl https://developer-portal.service.justice.gov.uk/robots.txt returns expected rules after deployment
 Core docs routes are not blocked
 /search, /api/, /_next/ are disallowed

## Follow-up
Rules should be reviewed once Issue #281 (automated content refresh) is delivered. At that point either relax disallowed paths or replace with a long-term indexing policy.