### PR TITLE
Removes security guidance

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -37,17 +37,6 @@
       "enabled": true
     },
     {
-      "id": "security-guidance",
-      "name": "Cyber and Technical Security Guidance",
-      "description": "Ministry of Justice cyber and technical security guidance.",
-      "category": "security",
-      "repo": "ministryofjustice/security-guidance",
-      "branch": "main",
-      "docsPath": "docs",
-      "format": "markdown",
-      "enabled": true
-    },
-    {
       "id": "cloud-optimisation-and-accountability",
       "name": "Cloud Optimisation and Accountability",
       "description": "Documentation source for Cloud Optimisation and Accountability.",


### PR DESCRIPTION
# Introduction :pencil2:

The security guidance is no longer being publicly hosted and is being kept in Sharepoint: https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Security-Policy-and-Guidance(1).aspx

See this slack thread for reference: https://mojdt.slack.com/archives/C52LPHPK8/p1782815064137709

## Resolution :heavy_check_mark:

Removes the security guidance documentation source.

## Miscellaneous :heavy_plus_sign:

We could look to add a link to the internal site as part of a seperate PR.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>