### PR TITLE
bug/Updated the nginx config to improve security and default handling

### DIFF
--- a/.github/nginx/default.conf
+++ b/.github/nginx/default.conf
@@ -2,6 +2,10 @@ server {
   listen 8080;
   server_name _;
 
+  # Behind ingress, avoid emitting absolute redirects that leak internal container port.
+  absolute_redirect off;
+  port_in_redirect off;
+
   root /usr/share/nginx/html;
   index index.html;
 
@@ -11,6 +15,8 @@ server {
   }
 
   location / {
-    try_files $uri $uri/ /index.html;
+    # Prefer serving directory index files directly (e.g. /cookie-policy -> /cookie-policy/index.html)
+    # so nginx does not generate an external trailing-slash redirect.
+    try_files $uri $uri/index.html $uri/ /index.html;
   }
 }


### PR DESCRIPTION
# Introduction :pencil2:

This impoves security of nginx ingress, by stopping port exposure and trailing / redirects also improves default page handling

## Resolution :heavy_check_mark:

Just changes to default.conf (nginx config)

## Miscellaneous :heavy_plus_sign:

Improve security 

