### PR TITLE
bug/Removed $uri/ from nginx

### DIFF
--- a/.github/nginx/default.conf
+++ b/.github/nginx/default.conf
@@ -17,6 +17,6 @@ server {
   location / {
     # Prefer serving directory index files directly (e.g. /cookie-policy -> /cookie-policy/index.html)
     # so nginx does not generate an external trailing-slash redirect.
-    try_files $uri $uri/index.html $uri/ /index.html;
+    try_files $uri $uri/index.html /index.html;
   }
 }


### PR DESCRIPTION
# Introduction :pencil2:

Removed $uri/ from nginx

## Resolution :heavy_check_mark:

Removed $uri/ from nginx

## Miscellaneous :heavy_plus_sign:

Stops nginx trying to redirect non trailing / 