### PR TITLE
Add GitHub User Guide and Terms of Service documentation

### DIFF
--- a/content/github/github.json
+++ b/content/github/github.json
@@ -1,0 +1,62 @@
+{
+  "title": "GitHub User Guide",
+  "summary": "Ministry of Justice standards and best practices for using GitHub. Learn how to effectively manage repositories, collaborate with teams, and follow our GitHub governance standards.",
+  "sections": [
+    {
+      "key": "getting-started",
+      "title": "Getting Started",
+      "description": "Essential information for new users — setting up your account, authentication, and basic repository access.",
+      "modifier": "inception"
+    },
+    {
+      "key": "best-practices",
+      "title": "Best Practices",
+      "description": "Recommended workflows, branching strategies, code review standards, and collaboration patterns.",
+      "modifier": "development"
+    },
+    {
+      "key": "governance",
+      "title": "Governance & Security",
+      "description": "Organisation standards, access control, security standards, and audit requirements.",
+      "modifier": "standards"
+    }
+  ],
+  "items": [
+        {
+    "slug": "terms-of-service",
+    "title": "GitHub Terms of Service",
+    "section": "governance",
+    "description": "Terms of Service for acceptable use of GitHub by Ministry of Justice teams.",
+    "owner": "Developer Experience team",
+    "lastReviewedOn": "2026-07-16",
+    "reviewIn": "12 months"
+    },
+    {
+      "slug": "github-setup",
+      "title": "Setting up GitHub",
+      "section": "getting-started",
+      "description": "Getting your GitHub account configured and accessing Ministry of Justice repositories.",
+      "owner": "Developer Experience team",
+      "lastReviewedOn": "2026-07-16",
+      "reviewIn": "6 months"
+    },
+    {
+      "slug": "branching-strategy",
+      "title": "Branching Strategy",
+      "section": "best-practices",
+      "description": "How we structure branches and manage feature development across MoJ projects.",
+      "owner": "Developer Experience team",
+      "lastReviewedOn": "2026-07-16",
+      "reviewIn": "6 months"
+    },
+    {
+      "slug": "code-review",
+      "title": "Code Review Standards",
+      "section": "best-practices",
+      "description": "Pull request process, review expectations, and approval workflows.",
+      "owner": "Developer Experience team",
+      "lastReviewedOn": "2026-07-16",
+      "reviewIn": "6 months"
+    }
+  ]
+}

--- a/content/github/terms-of-service.md
+++ b/content/github/terms-of-service.md
@@ -51,7 +51,7 @@ Restrictions apply regardless of file format or how the data is stored - whether
 
 **Do not** store data covered by privacy or payment regulations including, but not limited to:
 
-**Personal information**
+#### Personal information
 
 - full names
 - home addresses
@@ -64,7 +64,7 @@ Restrictions apply regardless of file format or how the data is stored - whether
 - medical information
 - biometric data
 
-**Payment card information**
+#### Payment card information
 
 - cardholder names
 - primary account numbers (**PAN**)

--- a/content/github/terms-of-service.md
+++ b/content/github/terms-of-service.md
@@ -1,4 +1,6 @@
-These are the official Terms of Service governing use of GitHub Enterprise Cloud by the Ministry of Justice. 
+# GitHub Terms of Service
+
+These are the official Terms of Service governing use of GitHub Enterprise Cloud by the Ministry of Justice.
 
 They define the mandatory security, compliance, and operational standards that **all users** must follow.
 
@@ -8,9 +10,14 @@ They define the mandatory security, compliance, and operational standards that *
 
 GitHub is a platform for collaborative development and version control of code. These Terms of Service establish three core principles:
 
-1. **Code only** — GitHub repositories **must only contain** source code and development artefacts. **Do not** store organisational, business, or operational data.
+1. **Code only** — GitHub repositories **must only contain** source code and
+   development artefacts. **Do not** store organisational, business, or operational
+   data.
 
-2. **Security first** — Repositories **must never contain** secrets, credentials, or sensitive information. **Do not** commit passwords, API keys, private keys, or regulated data such as PII (Personally Identifiable Information) and PCI (Payment Card Information).
+2. **Security first** — Repositories **must never contain** secrets, credentials,
+   or sensitive information. **Do not** commit passwords, API keys, private keys, or
+   regulated data such as PII (Personally Identifiable Information) and PCI
+   (Payment Card Information).
 
 3. **Compliance by design** — All users **must comply** with these standards to protect the organisation and the people we serve.
 
@@ -20,7 +27,9 @@ GitHub is a platform for collaborative development and version control of code. 
 
 This standard applies to **all staff and contributors** who can access or contribute to repositories used for MoJ work — regardless of role or seniority.
 
-**All repository visibility levels** (public, internal, and private) and **all repository content** (including code, configuration, commits, pull requests, issues, comments, logs, attachments, and generated artefacts) are covered.
+**All repository visibility levels** (public, internal, and private) and **all repository
+content** (including code, configuration, commits, pull requests, issues, comments, logs,
+attachments, and generated artefacts) are covered.
 
 Restrictions apply regardless of file format or how the data is stored - whether as structured files, plain text, compressed archives, or any other form.
 
@@ -43,9 +52,10 @@ Restrictions apply regardless of file format or how the data is stored - whether
 
 **Do not** store data covered by privacy or payment regulations, including:
 
-**PII (Personally Identifiable Information):** 
+**PII (Personally Identifiable Information):**
+
 - Full names
-- Home addresses 
+- Home addresses
 - Personal email addresses
 - Phone numbers
 - Dates of birth
@@ -55,7 +65,7 @@ Restrictions apply regardless of file format or how the data is stored - whether
 - Medical information
 - Biometric data
 
-**PCI (Payment Card Information):** 
+**PCI (Payment Card Information):**
 
 - Cardholder names
 - Primary account numbers (PAN)
@@ -67,7 +77,7 @@ Restrictions apply regardless of file format or how the data is stored - whether
 
 ### Secrets and credentials
 
-**Do not** store secrets in repositories, including: 
+**Do not** store secrets in repositories, including:
 
 - Passwords
 - API keys
@@ -108,7 +118,7 @@ These patterns are illustrative only — not official matching rules. Real produ
 When testing with MoJ-style identifiers, use visibly fake values with repeated digits or simple sequences:
 
 | Identifier | Format | Example |
-|---|---|---|
+| --- | --- | --- |
 | National Insurance number | 2 letters, 6 digits, suffix A–D | CD000000A |
 | PNC number | 4 digits/5–7 digits + letter | 0000/00000A |
 | CRO number | digits/2 digits + letter | 000/34B |
@@ -126,6 +136,7 @@ All teams and contributors **must**:
 - Treat AI-generated code and files as **untrusted** — review for data or secret leakage before committing
 
 In the event of a breach:
+
 - **Immediately remove and rotate** any exposed secret, and remove any accidentally committed PII, PCI, or organisational data
 - **Report** any exposure of secrets, PII, PCI, or organisational data as a security incident **immediately**
 
@@ -133,8 +144,12 @@ In the event of a breach:
 
 ## Compliance
 
-Any breach of these Terms of Service **must** be treated as a security and governance incident and escalated through the appropriate MoJ process. Repositories or workflows found to be non-compliant **may** be suspended until remediation is complete.
+Any breach of these Terms of Service **must** be treated as a security and governance
+incident and escalated through the appropriate MoJ process. Repositories or workflows
+found to be non-compliant **may** be suspended until remediation is complete.
 
 If you suspect a breach or security incident, [**report it immediately**](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/?agency=hq).
 
-If you are unsure whether something complies, contact the Developer Experience team via Slack [#ask-developer-experience-team](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8) or email DeveloperExperienceTeam@justice.gov.uk.
+If you are unsure whether something complies, contact the Developer Experience team
+via Slack [#ask-developer-experience-team](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8)
+or email <DeveloperExperienceTeam@justice.gov.uk>.

--- a/content/github/terms-of-service.md
+++ b/content/github/terms-of-service.md
@@ -1,6 +1,6 @@
 # GitHub Terms of Service
 
-These are the official Terms of Service governing use of GitHub Enterprise Cloud by the Ministry of Justice.
+These are the official Terms of Service governing use of GitHub by the Ministry of Justice.
 
 They define the mandatory security, compliance, and operational standards that **all users** must follow.
 
@@ -16,7 +16,7 @@ GitHub is a platform for collaborative development and version control of code. 
 
 2. **Security first** — Repositories **must never contain** secrets, credentials,
    or sensitive information. **Do not** commit passwords, API keys, private keys, or
-   regulated data such as PII (Personally Identifiable Information) and PCI
+   regulated data such as Personal Information and PCI
    (Payment Card Information).
 
 3. **Compliance by design** — All users **must comply** with these standards to protect the organisation and the people we serve.
@@ -50,9 +50,9 @@ Restrictions apply regardless of file format or how the data is stored - whether
 
 ### Personal or regulated data
 
-**Do not** store data covered by privacy or payment regulations, including:
+**Do not** store data covered by privacy or payment regulations including, but not limited to:
 
-**PII (Personally Identifiable Information):**
+**Personal Information:**
 
 - Full names
 - Home addresses
@@ -77,7 +77,7 @@ Restrictions apply regardless of file format or how the data is stored - whether
 
 ### Secrets and credentials
 
-**Do not** store secrets in repositories, including:
+**Do not** store secrets in repositories including, but not limited to:
 
 - Passwords
 - API keys
@@ -105,7 +105,7 @@ GitHub repositories are for development work. Acceptable content includes:
 The only permitted data-like content is synthetic test data required for automated testing. Test data **must**:
 
 - Be obviously fake and non-real
-- Contain no organisational, PII, or PCI data
+- Contain no organisational, Personal Information, or PCI data
 - Contain no secrets
 - Have a filename that clearly identifies it as test data (for example, `test-data.json`, `mock-users.test.json`)
 
@@ -115,7 +115,7 @@ The only permitted data-like content is synthetic test data required for automat
 
 These patterns are illustrative only — not official matching rules. Real production patterns may vary.
 
-When testing with MoJ-style identifiers, use visibly fake values with repeated digits or simple sequences:
+When testing, use visibly fake values with repeated digits or simple sequences:
 
 | Identifier | Format | Example |
 | --- | --- | --- |
@@ -131,14 +131,14 @@ When testing with MoJ-style identifiers, use visibly fake values with repeated d
 All teams and contributors **must**:
 
 - Store secrets using **approved secret management tools** — never in repository files
-- **Enable secret scanning** on repositories and in CI/CD pipelines
-- **Review pull requests** for accidental data or secret inclusion before merging
+- Ensure **appropriate security and access controls** are configured for your repositories and in CI/CD pipelines
+- **Review all code** entering repositories (e.g. from pull requests, third-party libraries) for accidental data or secrets exposure
 - Treat AI-generated code and files as **untrusted** — review for data or secret leakage before committing
 
 In the event of a breach:
 
-- **Immediately remove and rotate** any exposed secret, and remove any accidentally committed PII, PCI, or organisational data
-- **Report** any exposure of secrets, PII, PCI, or organisational data as a security incident **immediately**
+- **Immediately remove and rotate** any exposed secret, and remove any accidentally committed Personal Information, PCI, or organisational data
+- **Report** any exposure of secrets, Personal Information, PCI, or organisational data as a security incident **immediately**
 
 ---
 

--- a/content/github/terms-of-service.md
+++ b/content/github/terms-of-service.md
@@ -1,31 +1,30 @@
 # GitHub Terms of Service
 
-These are the official Terms of Service governing use of GitHub by the Ministry of Justice.
+These are the official terms of service governing use of GitHub by the Ministry of Justice (**MOJ**).
 
 They define the mandatory security, compliance, and operational standards that **all users** must follow.
 
 ---
 
-## Core Principles
+## Core principles
 
 GitHub is a platform for collaborative development and version control of code. These Terms of Service establish three core principles:
 
-1. **Code only** — GitHub repositories **must only contain** source code and
+**Code only** — GitHub repositories **must only contain** source code and
    development artefacts. **Do not** store organisational, business, or operational
    data.
 
-2. **Security first** — Repositories **must never contain** secrets, credentials,
+**Security first** — Repositories **must never contain** secrets, credentials,
    or sensitive information. **Do not** commit passwords, API keys, private keys, or
-   regulated data such as Personal Information and PCI
-   (Payment Card Information).
+   regulated data such as personal information and Payment Card Information (**PCI**).
 
-3. **Compliance by design** — All users **must comply** with these standards to protect the organisation and the people we serve.
+**Compliance by design** — All users **must comply** with these standards to protect the organisation and the people we serve.
 
 ---
 
 ## Scope
 
-This standard applies to **all staff and contributors** who can access or contribute to repositories used for MoJ work — regardless of role or seniority.
+This standard applies to **all staff and contributors** who can access or contribute to repositories used for MOJ work — regardless of role or seniority.
 
 **All repository visibility levels** (public, internal, and private) and **all repository
 content** (including code, configuration, commits, pull requests, issues, comments, logs,
@@ -35,83 +34,83 @@ Restrictions apply regardless of file format or how the data is stored - whether
 
 ---
 
-## What You Cannot Store
+## What you cannot store
 
 ### Organisational data
 
-**Do not** store organisation-specific data in repositories. This includes:
+**Do not** store organisation-specific data in repositories. This includes
 
-- Business, operational, or service data
-- Production data (including non-production copies)
-- Internal reports, extracts, or datasets
-- Data exports from internal systems
-- User, staff, or citizen records
-- Justice identifiers: Prisoner IDs, NOMIS IDs, PNC numbers, CRO numbers, CRNs, LAA Case Reference Numbers
+- business, operational, or service data
+- production data (including non-production copies)
+- internal reports, extracts, or datasets
+- data exports from internal systems
+- user, staff, or citizen records
+- justice identifiers: Prisoner IDs, NOMIS IDs, PNC numbers, CRO numbers, CRNs, LAA Case Reference Numbers
 
 ### Personal or regulated data
 
 **Do not** store data covered by privacy or payment regulations including, but not limited to:
 
-**Personal Information:**
+**Personal information**
 
-- Full names
-- Home addresses
-- Personal email addresses
-- Phone numbers
-- Dates of birth
-- National Insurance numbers
-- Passport numbers
-- Driving licence numbers
-- Medical information
-- Biometric data
+- full names
+- home addresses
+- personal email addresses
+- phone numbers
+- dates of birth
+- national Insurance numbers
+- passport numbers
+- driving licence numbers
+- medical information
+- biometric data
 
-**PCI (Payment Card Information):**
+**Payment card information**
 
-- Cardholder names
-- Primary account numbers (PAN)
-- Expiry dates
-- Service codes
-- Card verification values (CVV/CVC)
-- Magnetic stripe or chip track data
+- cardholder names
+- primary account numbers (**PAN**)
+- expiry dates
+- service codes
+- card verification values (**CVV**/**CVC**)
+- magnetic stripe or chip track data
 - PIN data
 
 ### Secrets and credentials
 
-**Do not** store secrets in repositories including, but not limited to:
+**Do not** store secrets in repositories including, but not limited to
 
-- Passwords
+- passwords
 - API keys
-- Private keys
-- Certificates
-- Connection strings
-- Credentials
-- Service account keys
+- private keys
+- certificates
+- connection strings
+- credentials
+- service account keys
 
 ---
 
-## What You Can Store
+## What you can store
 
-GitHub repositories are for development work. Acceptable content includes:
+GitHub repositories are for development work. Acceptable content includes
 
-- Source code and scripts
-- Configuration files and infrastructure as code
-- Documentation and technical guides
-- Automated test code and synthetic test fixtures
+- source code and scripts
+- configuration files and infrastructure as code
+- documentation and technical guides
+- automated test code and synthetic test fixtures
 - CI/CD pipeline definitions
-- Development tooling and build artefacts
+- development tooling and build artefacts
 
-### Synthetic Test Data
+### Synthetic test data
 
-The only permitted data-like content is synthetic test data required for automated testing. Test data **must**:
+The only permitted data-like content is synthetic test data required for automated testing. Test data **must**
 
-- Be obviously fake and non-real
-- Contain no organisational, Personal Information, or PCI data
-- Contain no secrets
-- Have a filename that clearly identifies it as test data (for example, `test-data.json`, `mock-users.test.json`)
+- be obviously fake and non-real
+- contain no organisational, Personal Information, or PCI data
+- contain no secrets
+- have a filename that clearly identifies it as test data (for example, `test-data.json`, `mock-users.test.json`)
 
 **Do not** use ambiguous names like `data.csv` or `users.json` for test datasets.
 
-### Synthetic Identifier Formats
+### Synthetic identifier formats
 
 These patterns are illustrative only — not official matching rules. Real production patterns may vary.
 
@@ -126,26 +125,26 @@ When testing, use visibly fake values with repeated digits or simple sequences:
 
 ---
 
-## Your Responsibilities
+## Your responsibilities
 
-All teams and contributors **must**:
+All teams and contributors **must**
 
-- Store secrets using **approved secret management tools** — never in repository files
-- Ensure **appropriate security and access controls** are configured for your repositories and in CI/CD pipelines
-- **Review all code** entering repositories (e.g. from pull requests, third-party libraries) for accidental data or secrets exposure
-- Treat AI-generated code and files as **untrusted** — review for data or secret leakage before committing
+- store secrets using **approved secret management tools** — never in repository files
+- ensure **appropriate security and access controls** are configured for your repositories and in CI/CD pipelines
+- **review all code** entering repositories (e.g. from pull requests, third-party libraries) for accidental data or secrets exposure
+- treat AI-generated code and files as **untrusted** — review for data or secret leakage before committing
 
 In the event of a breach:
 
-- **Immediately remove and rotate** any exposed secret, and remove any accidentally committed Personal Information, PCI, or organisational data
-- **Report** any exposure of secrets, Personal Information, PCI, or organisational data as a security incident **immediately**
+- **Immediately remove and rotate** any exposed secret, and remove any accidentally committed personal information, PCI, or organisational data
+- **Report** any exposure of secrets, personal information, PCI, or organisational data as a security incident **immediately**
 
 ---
 
 ## Compliance
 
 Any breach of these Terms of Service **must** be treated as a security and governance
-incident and escalated through the appropriate MoJ process. Repositories or workflows
+incident and escalated through the appropriate MOJ process. Repositories or workflows
 found to be non-compliant **may** be suspended until remediation is complete.
 
 If you suspect a breach or security incident, [**report it immediately**](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/?agency=hq).

--- a/content/github/terms-of-service.md
+++ b/content/github/terms-of-service.md
@@ -1,0 +1,140 @@
+These are the official Terms of Service governing use of GitHub Enterprise Cloud by the Ministry of Justice. 
+
+They define the mandatory security, compliance, and operational standards that **all users** must follow.
+
+---
+
+## Core Principles
+
+GitHub is a platform for collaborative development and version control of code. These Terms of Service establish three core principles:
+
+1. **Code only** — GitHub repositories **must only contain** source code and development artefacts. **Do not** store organisational, business, or operational data.
+
+2. **Security first** — Repositories **must never contain** secrets, credentials, or sensitive information. **Do not** commit passwords, API keys, private keys, or regulated data such as PII (Personally Identifiable Information) and PCI (Payment Card Information).
+
+3. **Compliance by design** — All users **must comply** with these standards to protect the organisation and the people we serve.
+
+---
+
+## Scope
+
+This standard applies to **all staff and contributors** who can access or contribute to repositories used for MoJ work — regardless of role or seniority.
+
+**All repository visibility levels** (public, internal, and private) and **all repository content** (including code, configuration, commits, pull requests, issues, comments, logs, attachments, and generated artefacts) are covered.
+
+Restrictions apply regardless of file format or how the data is stored - whether as structured files, plain text, compressed archives, or any other form.
+
+---
+
+## What You Cannot Store
+
+### Organisational data
+
+**Do not** store organisation-specific data in repositories. This includes:
+
+- Business, operational, or service data
+- Production data (including non-production copies)
+- Internal reports, extracts, or datasets
+- Data exports from internal systems
+- User, staff, or citizen records
+- Justice identifiers: Prisoner IDs, NOMIS IDs, PNC numbers, CRO numbers, CRNs, LAA Case Reference Numbers
+
+### Personal or regulated data
+
+**Do not** store data covered by privacy or payment regulations, including:
+
+**PII (Personally Identifiable Information):** 
+- Full names
+- Home addresses 
+- Personal email addresses
+- Phone numbers
+- Dates of birth
+- National Insurance numbers
+- Passport numbers
+- Driving licence numbers
+- Medical information
+- Biometric data
+
+**PCI (Payment Card Information):** 
+
+- Cardholder names
+- Primary account numbers (PAN)
+- Expiry dates
+- Service codes
+- Card verification values (CVV/CVC)
+- Magnetic stripe or chip track data
+- PIN data
+
+### Secrets and credentials
+
+**Do not** store secrets in repositories, including: 
+
+- Passwords
+- API keys
+- Private keys
+- Certificates
+- Connection strings
+- Credentials
+- Service account keys
+
+---
+
+## What You Can Store
+
+GitHub repositories are for development work. Acceptable content includes:
+
+- Source code and scripts
+- Configuration files and infrastructure as code
+- Documentation and technical guides
+- Automated test code and synthetic test fixtures
+- CI/CD pipeline definitions
+- Development tooling and build artefacts
+
+### Synthetic Test Data
+
+The only permitted data-like content is synthetic test data required for automated testing. Test data **must**:
+
+- Be obviously fake and non-real
+- Contain no organisational, PII, or PCI data
+- Contain no secrets
+- Have a filename that clearly identifies it as test data (for example, `test-data.json`, `mock-users.test.json`)
+
+**Do not** use ambiguous names like `data.csv` or `users.json` for test datasets.
+
+### Synthetic Identifier Formats
+
+These patterns are illustrative only — not official matching rules. Real production patterns may vary.
+
+When testing with MoJ-style identifiers, use visibly fake values with repeated digits or simple sequences:
+
+| Identifier | Format | Example |
+|---|---|---|
+| National Insurance number | 2 letters, 6 digits, suffix A–D | CD000000A |
+| PNC number | 4 digits/5–7 digits + letter | 0000/00000A |
+| CRO number | digits/2 digits + letter | 000/34B |
+| LAA case reference | 11 digits/letter/letter/digit | 00000000000/A/A/1 |
+
+---
+
+## Your Responsibilities
+
+All teams and contributors **must**:
+
+- Store secrets using **approved secret management tools** — never in repository files
+- **Enable secret scanning** on repositories and in CI/CD pipelines
+- **Review pull requests** for accidental data or secret inclusion before merging
+- Treat AI-generated code and files as **untrusted** — review for data or secret leakage before committing
+
+In the event of a breach:
+- **Immediately remove and rotate** any exposed secret, and remove any accidentally committed PII, PCI, or organisational data
+- **Report** any exposure of secrets, PII, PCI, or organisational data as a security incident **immediately**
+
+---
+
+## Compliance
+
+Any breach of these Terms of Service **must** be treated as a security and governance incident and escalated through the appropriate MoJ process. Repositories or workflows found to be non-compliant **may** be suspended until remediation is complete.
+
+If you suspect a breach or security incident, [**report it immediately**](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/?agency=hq).
+
+If you are unsure whether something complies, contact the Developer Experience team via Slack [#ask-developer-experience-team](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8) or email DeveloperExperienceTeam@justice.gov.uk.

--- a/content/products/products.json
+++ b/content/products/products.json
@@ -3,7 +3,7 @@
     "slug": "github",
     "name": "GitHub",
     "category": "platforms",
-    "description": "GitHub Enterprise Cloud is a foundational platform for version control and collaboration across the Ministry of Justice. Provides centralised code repositories, code review, automated CI/CD, and AI-assisted development with GitHub Copilot.",
+    "description": "GitHub is a foundational platform for version control and collaboration across the Ministry of Justice. Provides centralised code repositories, code review, automated CI/CD, and AI-assisted development with GitHub Copilot.",
     "owner": "Developer Experience team",
     "slackChannel": "#developer-experience-team",
     "docsUrl": "/github",

--- a/content/products/products.json
+++ b/content/products/products.json
@@ -1,5 +1,16 @@
 [
   {
+    "slug": "github",
+    "name": "GitHub",
+    "category": "platforms",
+    "description": "GitHub Enterprise Cloud is a foundational platform for version control and collaboration across the Ministry of Justice. Provides centralised code repositories, code review, automated CI/CD, and AI-assisted development with GitHub Copilot.",
+    "owner": "Developer Experience team",
+    "slackChannel": "#developer-experience-team",
+    "docsUrl": "/github",
+    "status": "live",
+    "tags": ["github", "github-actions", "ci-cd", "copilot"]
+  },
+  {
     "slug": "cloud-platform",
     "name": "Cloud Platform",
     "category": "platforms",

--- a/src/app/github/[slug]/page.tsx
+++ b/src/app/github/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { getReviewStatus } from '@/lib/review';
 import { MetaBar } from '@/components/templateRender/MetaBar';
 import { PageIntro } from '@/components/templateRender/PageIntro';
 import { TagRow } from '@/components/templateRender/TagRow';
-import guidelines from '../../../../content/guidelines/guidelines.json';
+import github from '../../../../content/github/github.json';
 import { markdownToHtml } from '@/lib/markdown/markdownToHtml';
 import { getGithubPage } from '@/lib/docs';
 import { GuidelinesContent } from '@/types/guidelines';
@@ -17,7 +17,7 @@ import { ReviewBadge } from '@/components/templateRender/ReviewBadge';
 
 type Params = { slug: string };
 
-const pageContent = guidelines as GuidelinesContent;
+const pageContent = github as GuidelinesContent;
 
 export function generateStaticParams() {
   return pageContent.items
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
   return { title: guideline.title };
 }
 
-export default async function GuidelineDetailPage({ params }: { params: Promise<Params> }) {
+export default async function GithubDetailPage({ params }: { params: Promise<Params> }) {
   const { slug } = await params;
   const guideline = pageContent.items.find((item) => item.slug === slug);
 
@@ -50,7 +50,7 @@ export default async function GuidelineDetailPage({ params }: { params: Promise<
     return (
       <div className="govuk-width-container">
         <Breadcrumbs
-          items={[{ label: pageContent.title, href: '/guidelines' }, { label: guideline.title }]}
+          items={[{ label: pageContent.title, href: '/github' }, { label: guideline.title }]}
         />
 
         <div className="govuk-grid-row">
@@ -95,7 +95,7 @@ If you have questions, reach out to the ${guideline.owner} team.
   return (
     <div className="govuk-width-container">
       <Breadcrumbs
-        items={[{ label: pageContent.title, href: '/guidelines' }, { label: guideline.title }]}
+        items={[{ label: pageContent.title, href: '/github' }, { label: guideline.title }]}
       />
 
       <div className="govuk-grid-row">

--- a/src/app/github/page.tsx
+++ b/src/app/github/page.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+import { Breadcrumbs } from '@/components/Breadcrumbs';
+import { ChatBot } from '@/components/ChatBot';
+import { PageIntro } from '@/components/templateRender/PageIntro';
+import github from '../../../content/github/github.json';
+import { GuidelinesContent } from '@/types/guidelines';
+
+export default function GitHubPage() {
+  const pageContent = github as GuidelinesContent;
+
+  return (
+    <div className="govuk-width-container">
+      <Breadcrumbs items={[{ label: pageContent.title }]} />
+
+      <PageIntro
+        title={pageContent.title}
+        summary={pageContent.summary}
+        summaryClassName="govuk-body-l"
+      />
+
+      {pageContent.sections.map((section) => {
+        const sectionGuidelines = pageContent.items.filter((item) => item.section === section.key);
+
+        if (sectionGuidelines.length === 0) {
+          return null;
+        }
+
+        return (
+          <section
+            key={section.key}
+            className={`app-phase-card app-phase-card--${section.modifier}`}
+          >
+            <h2 className="govuk-heading-l govuk-!-margin-bottom-1">{section.title}</h2>
+
+            <p className="govuk-body">{section.description}</p>
+
+            <ul className="govuk-list">
+              {sectionGuidelines.map((item) => (
+                <li key={item.slug}>
+                  {item.externalUrl ? (
+                    <a
+                      href={item.externalUrl}
+                      className="govuk-link govuk-link--no-visited-state"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {item.title}
+                      <span className="govuk-visually-hidden"> (opens in a new tab)</span>
+                    </a>
+                  ) : (
+                    <Link
+                      href={`/github/${item.slug}`}
+                      className="govuk-link govuk-link--no-visited-state"
+                    >
+                      {item.title}
+                    </Link>
+                  )}
+
+                  <span className="govuk-body-s" style={{ color: '#505a5f', marginLeft: 8 }}>
+                    — {item.description}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+
+      <ChatBot />
+    </div>
+  );
+}

--- a/src/app/guidelines/[slug]/page.tsx
+++ b/src/app/guidelines/[slug]/page.tsx
@@ -10,7 +10,7 @@ import { PageIntro } from '@/components/templateRender/PageIntro';
 import { TagRow } from '@/components/templateRender/TagRow';
 import guidelines from '../../../../content/guidelines/guidelines.json';
 import { markdownToHtml } from '@/lib/markdown/markdownToHtml';
-import { getGithubPage } from '@/lib/docs';
+import { getGuidelinePage } from '@/lib/docs';
 import { GuidelinesContent } from '@/types/guidelines';
 import { ReviewStatus } from '@/types';
 import { ReviewBadge } from '@/components/templateRender/ReviewBadge';
@@ -76,7 +76,7 @@ export default async function GuidelineDetailPage({ params }: { params: Promise<
     );
   }
 
-  const pageData = getGithubPage(guideline.slug);
+  const pageData = getGuidelinePage(guideline.slug);
 
   const content = pageData
     ? await markdownToHtml(pageData.content)

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -29,6 +29,30 @@ export function getGuidelinePage(slug: string): { content: string } | null {
   return null;
 }
 
+const GITHUB_DIR = path.join(process.cwd(), 'content', 'github');
+
+/**
+ * Get a single GitHub guide page by slug
+ */
+export function getGithubPage(slug: string): { content: string } | null {
+  let filePath = path.join(GITHUB_DIR, `${slug}.mdx`);
+
+  if (fs.existsSync(filePath)) {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const { content } = matter(raw);
+    return { content };
+  }
+  filePath = path.join(GITHUB_DIR, `${slug}.md`);
+
+  if (fs.existsSync(filePath)) {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const { content } = matter(raw);
+    return { content };
+  }
+
+  return null;
+}
+
 const DOCS_DIR = path.join(process.cwd(), 'content', 'docs');
 
 /**


### PR DESCRIPTION
# Introduction :pencil2:

Define/Publish acceptable "terms of service" for GitHub - https://github.com/ministryofjustice/moj-github-discovery/issues/194

## Resolution :heavy_check_mark:

This pull request introduces a new GitHub user guide section to the documentation platform, including governance standards, best practices, and a detailed Terms of Service. It adds structured content and implements new pages and logic for rendering GitHub-specific guidelines, integrating them into the site navigation and product listings.

**GitHub User Guide Content & Standards**

* Added a new `github.json` file defining the structure, sections, and items for the GitHub User Guide, including "Getting Started," "Best Practices," and "Governance & Security" sections, each with associated guidelines. Some of these are just placeholders for now until we finalise any more GH documentation for publication
* Added a comprehensive `terms-of-service.md` detailing mandatory security, compliance, and operational standards for GitHub use within the Ministry of Justice.

**Product & Navigation Integration**

* Registered GitHub as a product in `products.json`, with metadata for ownership, documentation, and tags, making it discoverable in the product catalog.

**Frontend Page Implementation**

* Implemented `/github` and `/github/[slug]` pages to display the guide overview and individual guideline details, including sectioned listings, content rendering, and support for external links.

**Backend Logic**

* Added `getGithubPage` to `docs.ts` for loading guideline markdown/MDX files by slug, supporting the new GitHub documentation structure.
## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>