### PR TITLE
feat: add workflow to automatically add new issues to the project

### DIFF
--- a/.github/workflows/add-new-issues-to-project.yml
+++ b/.github/workflows/add-new-issues-to-project.yml
@@ -1,0 +1,23 @@
+---
+name: 🗂 Add New Issues to Project
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  call-reusable-workflow:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-add-issue-to-project.yml
+    with:
+      project-title: "👩‍💻 Developer Experience Team"
+      project-fields-json: >-
+        {"Status":"👇 To do","👏 Team":"👾 Engineering Portal","🤩 Refined?":"👎 Unrefined"}
+    secrets:
+      app-client-id: ${{ secrets.ISSUE_ORCHESTRATOR_GH_APP_CLIENT_ID }}
+      app-private-key: ${{ secrets.ISSUE_ORCHESTRATOR_GH_APP_PRIVATE_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Introduction :pencil2:

In a DevEX Ways of Working session I took an action to look at the automatic labelling of tickets at point of creation https://mojdt.slack.com/archives/C0AH5GW3AQK/p1782989785962249

More specifically, when we raise new tickets they need to be added to the Developer Experience Team project and then certain project fields need to be set so they show up in our backlog correctly.

## Resolution :heavy_check_mark:

This pull request adds a new GitHub Actions workflow to automatically add newly opened issues to a specific project board. The workflow is triggered when an issue is opened and uses a reusable workflow to handle the assignment and field population.

**Automation for Issue Triage:**

* Added `.github/workflows/add-new-issues-to-project.yml` to automatically add new issues to the "👩‍💻 Developer Experience Team" project with predefined field values when an issue is opened.
* Configured the workflow to use secrets for authentication and Slack notifications.
## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>