### PR TITLE
fix: update path to reusable workflow 

### DIFF
--- a/.github/workflows/add-new-issues-to-project.yml
+++ b/.github/workflows/add-new-issues-to-project.yml
@@ -12,7 +12,7 @@ jobs:
   call-reusable-workflow:
     permissions:
       contents: read
-    uses: ./.github/workflows/reusable-add-issue-to-project.yml
+    uses: https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/blob/main/.github/workflows/reusable-add-issue-to-project.yml
     with:
       project-title: "👩‍💻 Developer Experience Team"
       project-fields-json: >-


### PR DESCRIPTION
This pull request updates the workflow configuration to reference a reusable workflow from a remote repository instead of a local file. This change ensures the workflow uses the latest shared logic from the Ministry of Justice engineering platform.

Workflow configuration update:

* Updated the `call-reusable-workflow` job in `.github/workflows/add-new-issues-to-project.yml` to use the reusable workflow via a remote URL instead of a local path.