### PR TITLE
fix: update reusable workflow reference to use correct format

### DIFF
--- a/.github/workflows/add-new-issues-to-project.yml
+++ b/.github/workflows/add-new-issues-to-project.yml
@@ -12,7 +12,7 @@ jobs:
   call-reusable-workflow:
     permissions:
       contents: read
-    uses: https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/blob/main/.github/workflows/reusable-add-issue-to-project.yml
+    uses: ministryofjustice/ministry-of-justice-engineering-platform/.github/workflows/reusable-add-issue-to-project.yml@main
     with:
       project-title: "👩‍💻 Developer Experience Team"
       project-fields-json: >-


### PR DESCRIPTION

This pull request updates the workflow configuration to use the correct syntax for referencing a reusable workflow in GitHub Actions. The change ensures that the workflow source is properly versioned and referenced.

Workflow configuration update:

* Updated the `uses` syntax in `.github/workflows/add-new-issues-to-project.yml` to reference the reusable workflow by repository and branch, rather than by URL.