### PR TITLE
fix: Improve GitHub doc page styling

### DIFF
--- a/src/app/github/[slug]/page.tsx
+++ b/src/app/github/[slug]/page.tsx
@@ -102,12 +102,7 @@ If you have questions, reach out to the ${guideline.owner} team.
         <div className="govuk-grid-column-two-thirds">
           {section && <TagRow categoryTag={section.title} />}
 
-          <PageIntro
-            title={guideline.title}
-            titleClassName="govuk-heading-xl govuk-!-margin-top-2 govuk-!-margin-bottom-2"
-          />
-
-          <div className="app-prose-scope" dangerouslySetInnerHTML={{ __html: content }} />
+          <div className="app-prose-scope app-github-content" dangerouslySetInnerHTML={{ __html: content }} />
 
           <MetaBar
             items={[

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -570,6 +570,27 @@ html {
   }
 }
 
+// GitHub content specific styles
+.app-github-content {
+  h1 {
+    @extend .govuk-heading-xl;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  ul, ol {
+    font-size: 19px;
+    line-height: 1.3157894737;
+    margin-top: 0;
+    margin-bottom: 20px;
+    padding-left: 20px;
+  }
+
+  li {
+    margin-bottom: 5px;
+  }
+}
+
 // Search
 .app-search {
   position: relative;


### PR DESCRIPTION
# Introduction :pencil2:

The GitHub User Guide content has some visual issues...

1. The page title derived from the `github.json` and Header 1 of each `.MD` file are both displayed which is a duplication
2. The bullet point lists in the `.MD` files are displaying with much smaller text than the rest of the document

## Resolution :heavy_check_mark:

This pull request updates the way GitHub guideline content is styled and rendered to improve consistency with GOV.UK design standards. The main change is the introduction of a new CSS class to apply specific typography and spacing to GitHub content, ensuring better readability and visual alignment.

**Styling improvements for GitHub content:**

* Added a new `.app-github-content` CSS class in `globals.scss` to style headings, lists, and list items within GitHub content, applying GOV.UK typography and spacing.
* Updated `page.tsx` to apply the `.app-github-content` class to the guideline content container, ensuring the new styles are used. ([src/app/github/[slug]/page.tsxL105-R105](diffhunk://#diff-c45748588735b4118cc4a4d0921d982121ed1dd9448759b54a03126c76adb0d4L105-R105))
## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

## **BEFORE** changes:

<img width="659" height="342" alt="Screenshot 2026-07-29 at 09 10 18" src="https://github.com/user-attachments/assets/735993be-5aae-4bf2-a07d-129af58f181f" />
<img width="684" height="601" alt="Screenshot 2026-07-29 at 09 10 26" src="https://github.com/user-attachments/assets/6f322a2d-1494-4279-810a-972a0e462afa" />

## AFTER changes:
<img width="668" height="284" alt="Screenshot 2026-07-29 at 09 09 37" src="https://github.com/user-attachments/assets/e4b4ccf3-375a-46fe-9937-1cc039cfb0da" />

<img width="630" height="729" alt="Screenshot 2026-07-29 at 09 09 48" src="https://github.com/user-attachments/assets/405713a5-6abd-4f3b-a2ef-a29a734781e4" />


</details>