### PR TITLE
fix: doc links returning homepage instead of correct page

### DIFF
--- a/src/lib/markdown/paths.ts
+++ b/src/lib/markdown/paths.ts
@@ -89,16 +89,6 @@ export function normalizeMalformedDocsPathsInHtml(html: string): string {
   return html.replace(/\/docs\/([^/"?#]+)\/documentation\//g, '/docs/$1/');
 }
 
-export function ensureDocsTrailingSlash(path: string): string {
-  if (!path.startsWith('/docs/')) return path;
-  if (path.endsWith('/')) return path;
-
-  const last = path.split('/').pop() || '';
-  if (last.includes('.')) return path;
-
-  return `${path}/`;
-}
-
 export function rewriteAbsoluteGithubPagesDocsHref(href: string): string | null {
   let parsed: URL;
   try {
@@ -120,9 +110,7 @@ export function rewriteAbsoluteGithubPagesDocsHref(href: string): string | null 
 
   if (!pathname.startsWith('/docs/')) return null;
 
-  return `${withBasePath(
-    ensureDocsTrailingSlash(normalizeMalformedDocsHref(pathname)),
-  )}${parsed.search}${parsed.hash}`;
+  return `${withBasePath(normalizeMalformedDocsHref(pathname))}${parsed.search}${parsed.hash}`;
 }
 
 function escapeRegExp(value: string): string {

--- a/src/lib/markdown/processLinks.ts
+++ b/src/lib/markdown/processLinks.ts
@@ -6,7 +6,6 @@ import {
   withBasePath,
   stripBasePath,
   isBasePathPrefixed,
-  ensureDocsTrailingSlash,
   normalizeMalformedDocsHref,
   rewriteAbsoluteGithubPagesDocsHref,
 } from './paths';
@@ -44,9 +43,7 @@ function rewriteDocHref(href: string, ctx: DocsLinkContext): string {
     const withoutBase = stripBasePath(pathname);
 
     if (withoutBase.startsWith('/docs/')) {
-      return `${withBasePath(
-        ensureDocsTrailingSlash(normalizeMalformedDocsHref(withoutBase)),
-      )}${suffix}`;
+      return `${withBasePath(normalizeMalformedDocsHref(withoutBase))}${suffix}`;
     }
 
     if (withoutBase.startsWith('/assets/')) {
@@ -72,7 +69,7 @@ function rewriteDocHref(href: string, ctx: DocsLinkContext): string {
     ? `/docs/${ctx.sourceSlug}/${normalized}`
     : `/docs/${ctx.sourceSlug}`;
 
-  return `${withBasePath(ensureDocsTrailingSlash(rewritten))}${suffix}`;
+  return `${withBasePath(rewritten)}${suffix}`;
 }
 
 function rewriteAssetPath(pathname: string, suffix: string, ctx: DocsLinkContext): string | null {

--- a/tests/unit/lib/markdown/paths.test.ts
+++ b/tests/unit/lib/markdown/paths.test.ts
@@ -8,7 +8,6 @@ import {
   isBasePathPrefixed,
   withBasePath,
   stripBasePath,
-  ensureDocsTrailingSlash,
   normalizeMalformedDocsHref,
 } from '@/lib/markdown/paths';
 
@@ -103,14 +102,6 @@ describe('base path helpers', () => {
 });
 
 describe('docs helpers', () => {
-  it('ensures trailing slash for docs paths', () => {
-    expect(ensureDocsTrailingSlash('/docs/test/page')).toBe('/docs/test/page/');
-  });
-
-  it('does not modify file paths', () => {
-    expect(ensureDocsTrailingSlash('/docs/test/file.pdf')).toBe('/docs/test/file.pdf');
-  });
-
   it('normalizes malformed docs href', () => {
     expect(normalizeMalformedDocsHref('/docs/test/documentation/page')).toBe('/docs/test/page');
   });

--- a/tests/unit/lib/markdown/processLinks.test.ts
+++ b/tests/unit/lib/markdown/processLinks.test.ts
@@ -47,6 +47,39 @@ describe('rewriteDocAnchorLinks', () => {
 
     expect(result).toContain('/docs/test-source/page');
   });
+
+  it('does not add a trailing slash to rewritten /docs href values', () => {
+    const input = `<a href="/docs/test-source/some-page">link</a>`;
+
+    const result = rewriteDocAnchorLinks(input, ctx);
+
+    expect(result).toMatch(/href="\/docs\/test-source\/some-page"/);
+    expect(result).not.toMatch(/href="\/docs\/test-source\/some-page\/"/);
+  });
+
+  it('does not add a trailing slash to rewritten relative doc href values', () => {
+    const input = `<a href="other-page.md">link</a>`;
+
+    const result = rewriteDocAnchorLinks(input, ctx);
+
+    expect(result).not.toMatch(/href="[^"]+\/"/);
+  });
+
+  it('preserves query string on rewritten /docs href values', () => {
+    const input = `<a href="/docs/test-source/page?foo=bar">link</a>`;
+
+    const result = rewriteDocAnchorLinks(input, ctx);
+
+    expect(result).toContain('href="/docs/test-source/page?foo=bar"');
+  });
+
+  it('preserves hash on rewritten /docs href values', () => {
+    const input = `<a href="/docs/test-source/page#section">link</a>`;
+
+    const result = rewriteDocAnchorLinks(input, ctx);
+
+    expect(result).toContain('href="/docs/test-source/page#section"');
+  });
 });
 
 describe('rewriteDocAssetSources', () => {
@@ -90,6 +123,31 @@ describe('rewriteDocHref deeper cases', () => {
     const result = rewriteDocAnchorLinks(input, ctx);
 
     expect(result).toContain('/docs/');
+  });
+
+  it('rewrites absolute github.io doc URL to portal path without trailing slash', () => {
+    const input = `<a href="https://ministryofjustice.github.io/my-repo/docs/some-page">link</a>`;
+
+    const result = rewriteDocAnchorLinks(input, ctx);
+
+    expect(result).toContain('href="/docs/some-page"');
+    expect(result).not.toContain('href="/docs/some-page/"');
+  });
+
+  it('preserves query string on rewritten github.io doc URL', () => {
+    const input = `<a href="https://ministryofjustice.github.io/my-repo/docs/some-page?tab=1">link</a>`;
+
+    const result = rewriteDocAnchorLinks(input, ctx);
+
+    expect(result).toContain('href="/docs/some-page?tab=1"');
+  });
+
+  it('preserves hash on rewritten github.io doc URL', () => {
+    const input = `<a href="https://ministryofjustice.github.io/my-repo/docs/some-page#section">link</a>`;
+
+    const result = rewriteDocAnchorLinks(input, ctx);
+
+    expect(result).toContain('href="/docs/some-page#section"');
   });
 
   it('leaves /assets paths alone except basePath', () => {


### PR DESCRIPTION
Links in all ingested documentation were broken, clicking them returned the homepage rather than the linked page.

Root cause: ensureDocsTrailingSlash was appending a trailing slash to every rendered doc link (e.g. /docs/modernisation-platform/user-guide/some-page/). With trailingSlash: false in next.config.js, the static export generates some-page.html files. Nginx's try_files rule couldn't resolve a trailing-slash URL to the .html file, so it fell back to /index.html,serving the homepage.

Fix: Removed ensureDocsTrailingSlash and all call sites. Doc links now render without trailing slashes, matching the filenames the static export produces.

Testing: Built locally, confirmed rendered links have no trailing slashes and the corresponding .html files exist in the static output. All 324 unit tests pass.