### PR TITLE
#407 Fix Dev Portal Feedback Link

### DIFF
--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -14,6 +14,7 @@ export default function FeedbackPage() {
     const [hasConsent, setHasConsent] = useState(false);
     const [statusMessage, setStatusMessage] = useState<string | null>(null);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [submitState, setSubmitState] = useState<'idle' | 'submitting'>('idle');
     const postHogConfigured = isPostHogConfigured();
 
     useEffect(() => {
@@ -27,11 +28,12 @@ export default function FeedbackPage() {
     }, []);
 
     const canSubmit = useMemo(() => {
-        return hasConsent && postHogConfigured && textAreaValue.trim().length > 0;
-    }, [hasConsent, textAreaValue, postHogConfigured]);
+        return hasConsent && postHogConfigured && textAreaValue.trim().length > 0 && submitState !== 'submitting';
+    }, [hasConsent, textAreaValue, postHogConfigured, submitState]);
 
     const handleTextAreaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setTextareaValue(event.target.value);
+        setSubmitState('idle');
         if (errorMessage) {
             setErrorMessage(null);
         }
@@ -42,39 +44,48 @@ export default function FeedbackPage() {
 
     const submit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
+        if (submitState === 'submitting') {
+            return;
+        }
 
         const feedback = textAreaValue.trim();
+        setSubmitState('submitting');
 
         if (!feedback) {
             setErrorMessage('Please enter feedback before submitting.');
+            setSubmitState('idle');
             return;
         }
 
         if (!hasConsent) {
             setErrorMessage('Please accept analytics cookies before submitting feedback.');
+            setSubmitState('idle');
             return;
         }
 
         if (!isPostHogConfigured()) {
-            setErrorMessage('Feedback is unavailable because PostHog is not configured in this environment.');
+            setErrorMessage('Feedback could not be submitted because PostHog is not configured in this environment.');
+            setSubmitState('idle');
             return;
         }
 
         const win = window as any;
         if (!win.__posthog_initialized) {
             setErrorMessage('Analytics is still starting. Please try again in a moment.');
+            setSubmitState('idle');
             return;
         }
 
         posthog.capture('survey sent', {
             $survey_id: SURVEY_ID,
-            $response_text: feedback,
+            $survey_response: feedback,
             $source: 'feedback-page',
         });
 
         setTextareaValue('');
         setErrorMessage(null);
-        setStatusMessage('Thanks for your feedback. It has been submitted.');
+        setStatusMessage('Thank you for your feedback. It has been submitted.');
+        setSubmitState('idle');
     };
 
     return (
@@ -104,7 +115,7 @@ export default function FeedbackPage() {
             )}
 
             <form onSubmit={submit}>
-                <div className="govuk-form-group">
+                <div className={`govuk-form-group ${errorMessage ? 'govuk-form-group--error' : ''}`}>
                     <label className="govuk-label govuk-label--m" htmlFor="feedback-textarea">
                         Share your feedback
                     </label>
@@ -116,7 +127,7 @@ export default function FeedbackPage() {
                         id="feedback-textarea"
                         name="feedback"
                         rows={5}
-                        aria-describedby="feedback-textarea-hint feedback-textarea-error"
+                        aria-describedby={`feedback-textarea-hint ${errorMessage ? 'feedback-textarea-error' : ''}`}
                         value={textAreaValue}
                         onChange={handleTextAreaChange}
                     ></textarea>

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Breadcrumbs } from "@/components/Breadcrumbs";
-import { ChatBot } from "@/components/ChatBot";
+import { Breadcrumbs } from '@/components/Breadcrumbs';
+import { ChatBot } from '@/components/ChatBot';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import posthog from 'posthog-js';
 import { isCookieConsentAccepted, onCookieConsentChange } from '@/lib/cookieConsent';
@@ -10,153 +10,165 @@ import { isPostHogConfigured } from '@/lib/posthogStatus';
 const SURVEY_ID = '019fd742-f2ec-0000-8f8d-4c89390a17f5';
 
 export default function FeedbackPage() {
-    const [textAreaValue, setTextareaValue] = useState('');
-    const [hasConsent, setHasConsent] = useState(false);
-    const [statusMessage, setStatusMessage] = useState<string | null>(null);
-    const [errorMessage, setErrorMessage] = useState<string | null>(null);
-    const [submitState, setSubmitState] = useState<'idle' | 'submitting'>('idle');
-    const postHogConfigured = isPostHogConfigured();
+  const [textAreaValue, setTextareaValue] = useState('');
+  const [hasConsent, setHasConsent] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [submitState, setSubmitState] = useState<'idle' | 'submitting'>('idle');
+  const postHogConfigured = isPostHogConfigured();
 
-    useEffect(() => {
-        setHasConsent(isCookieConsentAccepted());
+  useEffect(() => {
+    setHasConsent(isCookieConsentAccepted());
 
-        const cleanup = onCookieConsentChange((value) => {
-            setHasConsent(value === 'accepted');
-        });
+    const cleanup = onCookieConsentChange((value) => {
+      setHasConsent(value === 'accepted');
+    });
 
-        return cleanup;
-    }, []);
+    return cleanup;
+  }, []);
 
-    const canSubmit = useMemo(() => {
-        return hasConsent && postHogConfigured && textAreaValue.trim().length > 0 && submitState !== 'submitting';
-    }, [hasConsent, textAreaValue, postHogConfigured, submitState]);
-
-    const handleTextAreaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        setTextareaValue(event.target.value);
-        setSubmitState('idle');
-        if (errorMessage) {
-            setErrorMessage(null);
-        }
-        if (statusMessage) {
-            setStatusMessage(null);
-        }
-    };
-
-    const submit = (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        if (submitState === 'submitting') {
-            return;
-        }
-
-        const feedback = textAreaValue.trim();
-        setSubmitState('submitting');
-
-        if (!feedback) {
-            setErrorMessage('Please enter feedback before submitting.');
-            setSubmitState('idle');
-            return;
-        }
-
-        if (!hasConsent) {
-            setErrorMessage('Please accept analytics cookies before submitting feedback.');
-            setSubmitState('idle');
-            return;
-        }
-
-        if (!isPostHogConfigured()) {
-            setErrorMessage('Feedback could not be submitted because PostHog is not configured in this environment.');
-            setSubmitState('idle');
-            return;
-        }
-
-        const win = window as any;
-        if (!win.__posthog_initialized) {
-            setErrorMessage('Analytics is still starting. Please try again in a moment.');
-            setSubmitState('idle');
-            return;
-        }
-
-        posthog.capture('survey sent', {
-            $survey_id: SURVEY_ID,
-            $survey_response: feedback,
-            $source: 'feedback-page',
-        });
-
-        setTextareaValue('');
-        setErrorMessage(null);
-        setStatusMessage('Thank you for your feedback. It has been submitted.');
-        setSubmitState('idle');
-    };
-
+  const canSubmit = useMemo(() => {
     return (
-        <div className="govuk-width-container">
-            <Breadcrumbs items={[{ label: 'Feedback' }]} />
-
-            <h1 className="govuk-heading-l">Feedback</h1>
-
-            {!hasConsent && (
-                <div className="govuk-warning-text" role="status" aria-live="polite">
-                    <span className="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong className="govuk-warning-text__text">
-                        <span className="govuk-visually-hidden">Warning</span>
-                        You need to accept analytics cookies before feedback can be submitted.
-                    </strong>
-                </div>
-            )}
-
-            {!postHogConfigured && (
-                <div className="govuk-warning-text" role="status" aria-live="polite">
-                    <span className="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong className="govuk-warning-text__text">
-                        <span className="govuk-visually-hidden">Warning</span>
-                        Feedback is unavailable because PostHog is not configured in this environment.
-                    </strong>
-                </div>
-            )}
-
-            <form onSubmit={submit}>
-                <div className={`govuk-form-group ${errorMessage ? 'govuk-form-group--error' : ''}`}>
-                    <label className="govuk-label govuk-label--m" htmlFor="feedback-textarea">
-                        Share your feedback
-                    </label>
-                    <div id="feedback-textarea-hint" className="govuk-hint">
-                        Please provide any general feedback you have about this site. Your feedback helps us improve the service.
-                    </div>
-                    <textarea
-                        className="govuk-textarea"
-                        id="feedback-textarea"
-                        name="feedback"
-                        rows={5}
-                        aria-describedby={`feedback-textarea-hint ${errorMessage ? 'feedback-textarea-error' : ''}`}
-                        value={textAreaValue}
-                        onChange={handleTextAreaChange}
-                    ></textarea>
-
-                    {errorMessage && (
-                        <p id="feedback-textarea-error" className="govuk-error-message" role="alert">
-                            <span className="govuk-visually-hidden">Error:</span> {errorMessage}
-                        </p>
-                    )}
-
-                    {statusMessage && (
-                        <p className="govuk-body" role="status" aria-live="polite">
-                            {statusMessage}
-                        </p>
-                    )}
-
-                    <button
-                        type="submit"
-                        className="govuk-button"
-                        data-module="govuk-button"
-                        disabled={!canSubmit}
-                        aria-disabled={!canSubmit}
-                    >
-                        Submit feedback
-                    </button>
-                </div>
-            </form>
-
-            <ChatBot />
-        </div>
+      hasConsent &&
+      postHogConfigured &&
+      textAreaValue.trim().length > 0 &&
+      submitState !== 'submitting'
     );
+  }, [hasConsent, textAreaValue, postHogConfigured, submitState]);
+
+  const handleTextAreaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTextareaValue(event.target.value);
+    setSubmitState('idle');
+    if (errorMessage) {
+      setErrorMessage(null);
+    }
+    if (statusMessage) {
+      setStatusMessage(null);
+    }
+  };
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitState === 'submitting') {
+      return;
+    }
+
+    const feedback = textAreaValue.trim();
+    setSubmitState('submitting');
+
+    if (!feedback) {
+      setErrorMessage('Please enter feedback before submitting.');
+      setSubmitState('idle');
+      return;
+    }
+
+    if (!hasConsent) {
+      setErrorMessage('Please accept analytics cookies before submitting feedback.');
+      setSubmitState('idle');
+      return;
+    }
+
+    if (!isPostHogConfigured()) {
+      setErrorMessage(
+        'Feedback could not be submitted because PostHog is not configured in this environment.',
+      );
+      setSubmitState('idle');
+      return;
+    }
+
+    const win = window as any;
+    if (!win.__posthog_initialized) {
+      setErrorMessage('Analytics is still starting. Please try again in a moment.');
+      setSubmitState('idle');
+      return;
+    }
+
+    posthog.capture('survey sent', {
+      $survey_id: SURVEY_ID,
+      $survey_response: feedback,
+      $source: 'feedback-page',
+    });
+
+    setTextareaValue('');
+    setErrorMessage(null);
+    setStatusMessage('Thank you for your feedback. It has been submitted.');
+    setSubmitState('idle');
+  };
+
+  return (
+    <div className="govuk-width-container">
+      <Breadcrumbs items={[{ label: 'Feedback' }]} />
+
+      <h1 className="govuk-heading-l">Feedback</h1>
+
+      {!hasConsent && (
+        <div className="govuk-warning-text" role="status" aria-live="polite">
+          <span className="govuk-warning-text__icon" aria-hidden="true">
+            !
+          </span>
+          <strong className="govuk-warning-text__text">
+            <span className="govuk-visually-hidden">Warning</span>
+            You need to accept analytics cookies before feedback can be submitted.
+          </strong>
+        </div>
+      )}
+
+      {!postHogConfigured && (
+        <div className="govuk-warning-text" role="status" aria-live="polite">
+          <span className="govuk-warning-text__icon" aria-hidden="true">
+            !
+          </span>
+          <strong className="govuk-warning-text__text">
+            <span className="govuk-visually-hidden">Warning</span>
+            Feedback is unavailable because PostHog is not configured in this environment.
+          </strong>
+        </div>
+      )}
+
+      <form onSubmit={submit}>
+        <div className={`govuk-form-group ${errorMessage ? 'govuk-form-group--error' : ''}`}>
+          <label className="govuk-label govuk-label--m" htmlFor="feedback-textarea">
+            Share your feedback
+          </label>
+          <div id="feedback-textarea-hint" className="govuk-hint">
+            Please provide any general feedback you have about this site. Your feedback helps us
+            improve the service.
+          </div>
+          <textarea
+            className="govuk-textarea"
+            id="feedback-textarea"
+            name="feedback"
+            rows={5}
+            aria-describedby={`feedback-textarea-hint ${errorMessage ? 'feedback-textarea-error' : ''}`}
+            value={textAreaValue}
+            onChange={handleTextAreaChange}
+          ></textarea>
+
+          {errorMessage && (
+            <p id="feedback-textarea-error" className="govuk-error-message" role="alert">
+              <span className="govuk-visually-hidden">Error:</span> {errorMessage}
+            </p>
+          )}
+
+          {statusMessage && (
+            <p className="govuk-body" role="status" aria-live="polite">
+              {statusMessage}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            className="govuk-button"
+            data-module="govuk-button"
+            disabled={!canSubmit}
+            aria-disabled={!canSubmit}
+          >
+            Submit feedback
+          </button>
+        </div>
+      </form>
+
+      <ChatBot />
+    </div>
+  );
 }

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ChatBot } from "@/components/ChatBot";
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import posthog from 'posthog-js';
+import { isCookieConsentAccepted, onCookieConsentChange } from '@/lib/cookieConsent';
+import { isPostHogConfigured } from '@/lib/posthogStatus';
+
+const SURVEY_ID = '019fd742-f2ec-0000-8f8d-4c89390a17f5';
+
+export default function FeedbackPage() {
+    const [textAreaValue, setTextareaValue] = useState('');
+    const [hasConsent, setHasConsent] = useState(false);
+    const [statusMessage, setStatusMessage] = useState<string | null>(null);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const postHogConfigured = isPostHogConfigured();
+
+    useEffect(() => {
+        setHasConsent(isCookieConsentAccepted());
+
+        const cleanup = onCookieConsentChange((value) => {
+            setHasConsent(value === 'accepted');
+        });
+
+        return cleanup;
+    }, []);
+
+    const canSubmit = useMemo(() => {
+        return hasConsent && postHogConfigured && textAreaValue.trim().length > 0;
+    }, [hasConsent, textAreaValue, postHogConfigured]);
+
+    const handleTextAreaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setTextareaValue(event.target.value);
+        if (errorMessage) {
+            setErrorMessage(null);
+        }
+        if (statusMessage) {
+            setStatusMessage(null);
+        }
+    };
+
+    const submit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const feedback = textAreaValue.trim();
+
+        if (!feedback) {
+            setErrorMessage('Please enter feedback before submitting.');
+            return;
+        }
+
+        if (!hasConsent) {
+            setErrorMessage('Please accept analytics cookies before submitting feedback.');
+            return;
+        }
+
+        if (!isPostHogConfigured()) {
+            setErrorMessage('Feedback is unavailable because PostHog is not configured in this environment.');
+            return;
+        }
+
+        const win = window as any;
+        if (!win.__posthog_initialized) {
+            setErrorMessage('Analytics is still starting. Please try again in a moment.');
+            return;
+        }
+
+        posthog.capture('survey sent', {
+            $survey_id: SURVEY_ID,
+            $response_text: feedback,
+            $source: 'feedback-page',
+        });
+
+        setTextareaValue('');
+        setErrorMessage(null);
+        setStatusMessage('Thanks for your feedback. It has been submitted.');
+    };
+
+    return (
+        <div className="govuk-width-container">
+            <Breadcrumbs items={[{ label: 'Feedback' }]} />
+
+            <h1 className="govuk-heading-l">Feedback</h1>
+
+            {!hasConsent && (
+                <div className="govuk-warning-text" role="status" aria-live="polite">
+                    <span className="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <strong className="govuk-warning-text__text">
+                        <span className="govuk-visually-hidden">Warning</span>
+                        You need to accept analytics cookies before feedback can be submitted.
+                    </strong>
+                </div>
+            )}
+
+            {!postHogConfigured && (
+                <div className="govuk-warning-text" role="status" aria-live="polite">
+                    <span className="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <strong className="govuk-warning-text__text">
+                        <span className="govuk-visually-hidden">Warning</span>
+                        Feedback is unavailable because PostHog is not configured in this environment.
+                    </strong>
+                </div>
+            )}
+
+            <form onSubmit={submit}>
+                <div className="govuk-form-group">
+                    <label className="govuk-label govuk-label--m" htmlFor="feedback-textarea">
+                        Share your feedback
+                    </label>
+                    <div id="feedback-textarea-hint" className="govuk-hint">
+                        Please provide any general feedback you have about this site. Your feedback helps us improve the service.
+                    </div>
+                    <textarea
+                        className="govuk-textarea"
+                        id="feedback-textarea"
+                        name="feedback"
+                        rows={5}
+                        aria-describedby="feedback-textarea-hint feedback-textarea-error"
+                        value={textAreaValue}
+                        onChange={handleTextAreaChange}
+                    ></textarea>
+
+                    {errorMessage && (
+                        <p id="feedback-textarea-error" className="govuk-error-message" role="alert">
+                            <span className="govuk-visually-hidden">Error:</span> {errorMessage}
+                        </p>
+                    )}
+
+                    {statusMessage && (
+                        <p className="govuk-body" role="status" aria-live="polite">
+                            {statusMessage}
+                        </p>
+                    )}
+
+                    <button
+                        type="submit"
+                        className="govuk-button"
+                        data-module="govuk-button"
+                        disabled={!canSubmit}
+                        aria-disabled={!canSubmit}
+                    >
+                        Submit feedback
+                    </button>
+                </div>
+            </form>
+
+            <ChatBot />
+        </div>
+    );
+}

--- a/tests/unit/app/feedback/Page.test.tsx
+++ b/tests/unit/app/feedback/Page.test.tsx
@@ -15,14 +15,13 @@ describe('Feedback page', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
-        document.cookie = 'moj_cookie_consent=; path=/; max-age=0';
-        delete (window as any).__posthog_initialized;
     });
 
     it('renders feedback form', () => {
+        // when the user is on the feedback page
         render(<FeedbackPage />);
 
+        // then the feedback form is displayed
         expect(screen.getByText('Feedback')).toBeInTheDocument();
         expect(screen.getByText('Please provide any general feedback you have about this site. Your feedback helps us improve the service.')).toBeInTheDocument();
         expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -30,29 +29,103 @@ describe('Feedback page', () => {
     });
 
     it('renders warning message when PostHog is not configured', () => {
+        // given PostHog is not configured
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+        // when the user is on the feedback page
         render(<FeedbackPage />);
 
+        // then the warning message is displayed
         expect(screen.getByText('Feedback is unavailable because PostHog is not configured in this environment.')).toBeInTheDocument();
     });
 
     it('renders warning message when cookies are not accepted', () => {
+        // given cookies are not accepted
+        document.cookie = 'moj_cookie_consent=rejected';
+
+        // when the user is on the feedback page
         render(<FeedbackPage />);
 
+        // then the warning message is displayed
         expect(screen.getByText('You need to accept analytics cookies before feedback can be submitted.')).toBeInTheDocument();
     });
 
     it('renders chatbot button', () => {
+        // when the user is on the feedback page
         render(<FeedbackPage />);
 
+        // then the chatbot button is displayed
         expect(screen.getByTestId('chatbot-button')).toBeInTheDocument();
     });
 
     it('allows users to submit feedback when cookies are accepted and PostHog is configured', async () => {
+        // given cookies are accepted and PostHog is configured
         process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
         document.cookie = 'moj_cookie_consent=accepted';
 
         render(<FeedbackPage />);
 
+        // when the user types feedback into the textarea
+        const user = userEvent.setup();
+        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        const feedbackText = 'This is a test feedback message.';
+
+        await user.type(feedbackTextarea, feedbackText);
+        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+        // then the submit button is enabled
+        await waitFor(() => {
+            expect(submitButton).toBeEnabled();
+        });
+    });
+
+    it('disables submit button when feedback textarea is empty', () => {
+        // given cookies are accepted and PostHog is configured
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=accepted';
+
+        render(<FeedbackPage />);
+
+        // when the user has not typed any feedback into the textarea
+        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        expect(feedbackTextarea).toHaveValue('');
+
+        // then the submit button is disabled
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        expect(submitButton).toBeDisabled();
+    });
+
+    it('warning message is removed once cookies are accepted', async () => {
+        // given cookies are not accepted and the warning message is displayed
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=rejected';
+        render(<FeedbackPage />);
+        expect(screen.getByText('You need to accept analytics cookies before feedback can be submitted.')).toBeInTheDocument();
+
+        // when the user accepts cookies
+        document.cookie = 'moj_cookie_consent=accepted';
+        act(() => {
+            window.dispatchEvent(new CustomEvent('cookieConsentChange', { detail: 'accepted' }));
+        });
+
+        // then the warning message is removed
+        await waitFor(() => {
+            expect(screen.queryByText('You need to accept analytics cookies before feedback can be submitted.')).not.toBeInTheDocument();
+        });
+    });
+
+    it('calls posthog API when feedback is submitted', async () => {
+        const captureMock = vi.mocked(posthog.capture);
+
+        // given cookies are accepted and PostHog is configured and initialised
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=accepted';
+        (window as any).__posthog_initialized = true;
+
+        render(<FeedbackPage />);
+
+        // when the user types feedback into the textarea and submits the form
         const user = userEvent.setup();
         const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
         const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
@@ -64,45 +137,124 @@ describe('Feedback page', () => {
         await waitFor(() => {
             expect(submitButton).toBeEnabled();
         });
+
+        await user.click(submitButton);
+
+        // then the posthog API is called with the correct parameters
+        expect(captureMock).toHaveBeenCalledWith('survey sent', {
+            $survey_response: feedbackText,
+            $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
+            $source: 'feedback-page',
+        });
     });
 
-    it('disables submit button when feedback textarea is empty', () => {
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=accepted';
+    it('displays error message when feedback is submitted without cookies accepted', async () => {
+        const captureMock = vi.mocked(posthog.capture);
 
-        render(<FeedbackPage />);
-
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        expect(submitButton).toBeDisabled();
-    });
-
-    it('warning message is not displayed once cookies are accepted', async () => {
+        // given cookies are not accepted
         process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
         document.cookie = 'moj_cookie_consent=rejected';
 
         render(<FeedbackPage />);
 
-        expect(screen.getByText('You need to accept analytics cookies before feedback can be submitted.')).toBeInTheDocument();
+        // when the user types feedback into the textarea and submits the form
+        const user = userEvent.setup();
+        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        const feedbackText = 'This is a test feedback message.';
 
-        document.cookie = 'moj_cookie_consent=accepted';
-        act(() => {
-            window.dispatchEvent(new CustomEvent('cookieConsentChange', { detail: 'accepted' }));
-        });
+        await user.type(feedbackTextarea, feedbackText);
+        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
 
-        await waitFor(() => {
-            expect(screen.queryByText('You need to accept analytics cookies before feedback can be submitted.')).not.toBeInTheDocument();
-        });
+        submitButton.removeAttribute('disabled');
+
+        await user.click(submitButton);
+
+        // then the error message is displayed and the feedback is not submitted
+        expect(await screen.findByText('Please accept analytics cookies before submitting feedback.')).toBeInTheDocument();
+        expect(captureMock).not.toHaveBeenCalled();
     });
 
-    it('calls posthog API when feedback is submitted', async () => {
+    it('displays error message when feedback is submitted without PostHog configured', async () => {
         const captureMock = vi.mocked(posthog.capture);
 
+        // given PostHog is not configured
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+        document.cookie = 'moj_cookie_consent=accepted';
+
+        render(<FeedbackPage />);
+
+        // when the user types feedback into the textarea and submits the form
+        const user = userEvent.setup();
+        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        const feedbackText = 'This is a test feedback message.';
+
+        await user.type(feedbackTextarea, feedbackText);
+        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+        submitButton.removeAttribute('disabled');
+
+        await user.click(submitButton);
+
+        // then the error message is displayed
+        expect(await screen.findByText('Feedback could not be submitted because PostHog is not configured in this environment.')).toBeInTheDocument();
+    });
+
+    it('displays error message when feedback is submitted without PostHog initialized', async () => {
+        // given PostHog is configured but not initialised
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=accepted';
+        (window as any).__posthog_initialized = false;
+
+        render(<FeedbackPage />);
+
+        // when the user types feedback into the textarea and submits the form
+        const user = userEvent.setup();
+        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        const feedbackText = 'This is a test feedback message.';
+
+        await user.type(feedbackTextarea, feedbackText);
+        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+        submitButton.removeAttribute('disabled');
+
+        await user.click(submitButton);
+
+        // then the error message is displayed
+        expect(await screen.findByText('Analytics is still starting. Please try again in a moment.')).toBeInTheDocument();
+    });
+
+    it('displays error message when feedback is submitted without any text', async () => {
+        // given cookies are accepted and PostHog is configured and initialised
         process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
         document.cookie = 'moj_cookie_consent=accepted';
         (window as any).__posthog_initialized = true;
 
         render(<FeedbackPage />);
 
+        // when the user submits the form without typing any feedback
+        const user = userEvent.setup();
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+
+        submitButton.removeAttribute('disabled');
+
+        await user.click(submitButton);
+
+        // then the error message is displayed
+        expect(await screen.findByText('Please enter feedback before submitting.')).toBeInTheDocument();
+    });
+
+    it('resets textarea after successful submission', async () => {
+        const captureMock = vi.mocked(posthog.capture);
+
+        // given cookies are accepted and PostHog is configured and initialised
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=accepted';
+        (window as any).__posthog_initialized = true;
+
+        render(<FeedbackPage />);
+
+        // when the user types feedback into the textarea and submits the form
         const user = userEvent.setup();
         const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
         const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
@@ -118,9 +270,51 @@ describe('Feedback page', () => {
         await user.click(submitButton);
 
         expect(captureMock).toHaveBeenCalledWith('survey sent', {
-            $response_text: feedbackText,
+            $survey_response: feedbackText,
             $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
             $source: 'feedback-page',
+        });
+
+        // then the textarea is reset to empty
+        await waitFor(() => {
+            expect(feedbackTextarea).toHaveValue('');
+        });
+    });
+
+    test('it displays a success message after successful submission', async () => {
+        const captureMock = vi.mocked(posthog.capture);
+
+        // given cookies are accepted and PostHog is configured and initialised
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=accepted';
+        (window as any).__posthog_initialized = true;
+
+        render(<FeedbackPage />);
+
+        // when the user types feedback into the textarea and submits the form
+        const user = userEvent.setup();
+        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        const feedbackText = 'This is a test feedback message.';
+
+        await user.type(feedbackTextarea, feedbackText);
+        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+        await waitFor(() => {
+            expect(submitButton).toBeEnabled();
+        });
+
+        await user.click(submitButton);
+
+        expect(captureMock).toHaveBeenCalledWith('survey sent', {
+            $survey_response: feedbackText,
+            $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
+            $source: 'feedback-page',
+        });
+
+        // then the success message is displayed
+        await waitFor(() => {
+            expect(screen.getByText('Thank you for your feedback. It has been submitted.')).toBeInTheDocument();
         });
     });
 });

--- a/tests/unit/app/feedback/Page.test.tsx
+++ b/tests/unit/app/feedback/Page.test.tsx
@@ -1,0 +1,126 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@tests/unit/mocks/AllMocks';
+import posthog from 'posthog-js';
+import FeedbackPage from '@/app/feedback/page';
+
+vi.mock('posthog-js', () => ({
+    __esModule: true,
+    default: {
+        capture: vi.fn(),
+    }
+}));
+
+describe('Feedback page', () => {
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+        document.cookie = 'moj_cookie_consent=; path=/; max-age=0';
+        delete (window as any).__posthog_initialized;
+    });
+
+    it('renders feedback form', () => {
+        render(<FeedbackPage />);
+
+        expect(screen.getByText('Feedback')).toBeInTheDocument();
+        expect(screen.getByText('Please provide any general feedback you have about this site. Your feedback helps us improve the service.')).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Submit feedback' })).toBeInTheDocument();
+    });
+
+    it('renders warning message when PostHog is not configured', () => {
+        render(<FeedbackPage />);
+
+        expect(screen.getByText('Feedback is unavailable because PostHog is not configured in this environment.')).toBeInTheDocument();
+    });
+
+    it('renders warning message when cookies are not accepted', () => {
+        render(<FeedbackPage />);
+
+        expect(screen.getByText('You need to accept analytics cookies before feedback can be submitted.')).toBeInTheDocument();
+    });
+
+    it('renders chatbot button', () => {
+        render(<FeedbackPage />);
+
+        expect(screen.getByTestId('chatbot-button')).toBeInTheDocument();
+    });
+
+    it('allows users to submit feedback when cookies are accepted and PostHog is configured', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=accepted';
+
+        render(<FeedbackPage />);
+
+        const user = userEvent.setup();
+        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        const feedbackText = 'This is a test feedback message.';
+
+        await user.type(feedbackTextarea, feedbackText);
+        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+        await waitFor(() => {
+            expect(submitButton).toBeEnabled();
+        });
+    });
+
+    it('disables submit button when feedback textarea is empty', () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=accepted';
+
+        render(<FeedbackPage />);
+
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        expect(submitButton).toBeDisabled();
+    });
+
+    it('warning message is not displayed once cookies are accepted', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=rejected';
+
+        render(<FeedbackPage />);
+
+        expect(screen.getByText('You need to accept analytics cookies before feedback can be submitted.')).toBeInTheDocument();
+
+        document.cookie = 'moj_cookie_consent=accepted';
+        act(() => {
+            window.dispatchEvent(new CustomEvent('cookieConsentChange', { detail: 'accepted' }));
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByText('You need to accept analytics cookies before feedback can be submitted.')).not.toBeInTheDocument();
+        });
+    });
+
+    it('calls posthog API when feedback is submitted', async () => {
+        const captureMock = vi.mocked(posthog.capture);
+
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+        document.cookie = 'moj_cookie_consent=accepted';
+        (window as any).__posthog_initialized = true;
+
+        render(<FeedbackPage />);
+
+        const user = userEvent.setup();
+        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+        const feedbackText = 'This is a test feedback message.';
+
+        await user.type(feedbackTextarea, feedbackText);
+        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+        await waitFor(() => {
+            expect(submitButton).toBeEnabled();
+        });
+
+        await user.click(submitButton);
+
+        expect(captureMock).toHaveBeenCalledWith('survey sent', {
+            $response_text: feedbackText,
+            $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
+            $source: 'feedback-page',
+        });
+    });
+});

--- a/tests/unit/app/feedback/Page.test.tsx
+++ b/tests/unit/app/feedback/Page.test.tsx
@@ -5,316 +5,339 @@ import posthog from 'posthog-js';
 import FeedbackPage from '@/app/feedback/page';
 
 vi.mock('posthog-js', () => ({
-    __esModule: true,
-    default: {
-        capture: vi.fn(),
-    }
+  __esModule: true,
+  default: {
+    capture: vi.fn(),
+  },
 }));
 
 describe('Feedback page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    beforeEach(() => {
-        vi.clearAllMocks();
+  it('renders feedback form', () => {
+    // when the user is on the feedback page
+    render(<FeedbackPage />);
+
+    // then the feedback form is displayed
+    expect(screen.getByText('Feedback')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Please provide any general feedback you have about this site. Your feedback helps us improve the service.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submit feedback' })).toBeInTheDocument();
+  });
+
+  it('renders warning message when PostHog is not configured', () => {
+    // given PostHog is not configured
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+    // when the user is on the feedback page
+    render(<FeedbackPage />);
+
+    // then the warning message is displayed
+    expect(
+      screen.getByText(
+        'Feedback is unavailable because PostHog is not configured in this environment.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders warning message when cookies are not accepted', () => {
+    // given cookies are not accepted
+    document.cookie = 'moj_cookie_consent=rejected';
+
+    // when the user is on the feedback page
+    render(<FeedbackPage />);
+
+    // then the warning message is displayed
+    expect(
+      screen.getByText('You need to accept analytics cookies before feedback can be submitted.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders chatbot button', () => {
+    // when the user is on the feedback page
+    render(<FeedbackPage />);
+
+    // then the chatbot button is displayed
+    expect(screen.getByTestId('chatbot-button')).toBeInTheDocument();
+  });
+
+  it('allows users to submit feedback when cookies are accepted and PostHog is configured', async () => {
+    // given cookies are accepted and PostHog is configured
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=accepted';
+
+    render(<FeedbackPage />);
+
+    // when the user types feedback into the textarea
+    const user = userEvent.setup();
+    const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+    const feedbackText = 'This is a test feedback message.';
+
+    await user.type(feedbackTextarea, feedbackText);
+    expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+    // then the submit button is enabled
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
+    });
+  });
+
+  it('disables submit button when feedback textarea is empty', () => {
+    // given cookies are accepted and PostHog is configured
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=accepted';
+
+    render(<FeedbackPage />);
+
+    // when the user has not typed any feedback into the textarea
+    const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(feedbackTextarea).toHaveValue('');
+
+    // then the submit button is disabled
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('warning message is removed once cookies are accepted', async () => {
+    // given cookies are not accepted and the warning message is displayed
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=rejected';
+    render(<FeedbackPage />);
+    expect(
+      screen.getByText('You need to accept analytics cookies before feedback can be submitted.'),
+    ).toBeInTheDocument();
+
+    // when the user accepts cookies
+    document.cookie = 'moj_cookie_consent=accepted';
+    act(() => {
+      window.dispatchEvent(new CustomEvent('cookieConsentChange', { detail: 'accepted' }));
     });
 
-    it('renders feedback form', () => {
-        // when the user is on the feedback page
-        render(<FeedbackPage />);
+    // then the warning message is removed
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          'You need to accept analytics cookies before feedback can be submitted.',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
 
-        // then the feedback form is displayed
-        expect(screen.getByText('Feedback')).toBeInTheDocument();
-        expect(screen.getByText('Please provide any general feedback you have about this site. Your feedback helps us improve the service.')).toBeInTheDocument();
-        expect(screen.getByRole('textbox')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Submit feedback' })).toBeInTheDocument();
+  it('calls posthog API when feedback is submitted', async () => {
+    const captureMock = vi.mocked(posthog.capture);
+
+    // given cookies are accepted and PostHog is configured and initialised
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=accepted';
+    (window as any).__posthog_initialized = true;
+
+    render(<FeedbackPage />);
+
+    // when the user types feedback into the textarea and submits the form
+    const user = userEvent.setup();
+    const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+    const feedbackText = 'This is a test feedback message.';
+
+    await user.type(feedbackTextarea, feedbackText);
+    expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
     });
 
-    it('renders warning message when PostHog is not configured', () => {
-        // given PostHog is not configured
-        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    await user.click(submitButton);
 
-        // when the user is on the feedback page
-        render(<FeedbackPage />);
+    // then the posthog API is called with the correct parameters
+    expect(captureMock).toHaveBeenCalledWith('survey sent', {
+      $survey_response: feedbackText,
+      $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
+      $source: 'feedback-page',
+    });
+  });
 
-        // then the warning message is displayed
-        expect(screen.getByText('Feedback is unavailable because PostHog is not configured in this environment.')).toBeInTheDocument();
+  it('displays error message when feedback is submitted without cookies accepted', async () => {
+    const captureMock = vi.mocked(posthog.capture);
+
+    // given cookies are not accepted
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=rejected';
+
+    render(<FeedbackPage />);
+
+    // when the user types feedback into the textarea and submits the form
+    const user = userEvent.setup();
+    const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+    const feedbackText = 'This is a test feedback message.';
+
+    await user.type(feedbackTextarea, feedbackText);
+    expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+    submitButton.removeAttribute('disabled');
+
+    await user.click(submitButton);
+
+    // then the error message is displayed and the feedback is not submitted
+    expect(
+      await screen.findByText('Please accept analytics cookies before submitting feedback.'),
+    ).toBeInTheDocument();
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it('displays error message when feedback is submitted without PostHog configured', async () => {
+    // given PostHog is not configured
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    document.cookie = 'moj_cookie_consent=accepted';
+
+    render(<FeedbackPage />);
+
+    // when the user types feedback into the textarea and submits the form
+    const user = userEvent.setup();
+    const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+    const feedbackText = 'This is a test feedback message.';
+
+    await user.type(feedbackTextarea, feedbackText);
+    expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+    submitButton.removeAttribute('disabled');
+
+    await user.click(submitButton);
+
+    // then the error message is displayed
+    expect(
+      await screen.findByText(
+        'Feedback could not be submitted because PostHog is not configured in this environment.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('displays error message when feedback is submitted without PostHog initialized', async () => {
+    // given PostHog is configured but not initialised
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=accepted';
+    (window as any).__posthog_initialized = false;
+
+    render(<FeedbackPage />);
+
+    // when the user types feedback into the textarea and submits the form
+    const user = userEvent.setup();
+    const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+    const feedbackText = 'This is a test feedback message.';
+
+    await user.type(feedbackTextarea, feedbackText);
+    expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+    submitButton.removeAttribute('disabled');
+
+    await user.click(submitButton);
+
+    // then the error message is displayed
+    expect(
+      await screen.findByText('Analytics is still starting. Please try again in a moment.'),
+    ).toBeInTheDocument();
+  });
+
+  it('displays error message when feedback is submitted without any text', async () => {
+    // given cookies are accepted and PostHog is configured and initialised
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=accepted';
+    (window as any).__posthog_initialized = true;
+
+    render(<FeedbackPage />);
+
+    // when the user submits the form without typing any feedback
+    const user = userEvent.setup();
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+
+    submitButton.removeAttribute('disabled');
+
+    await user.click(submitButton);
+
+    // then the error message is displayed
+    expect(await screen.findByText('Please enter feedback before submitting.')).toBeInTheDocument();
+  });
+
+  it('resets textarea after successful submission', async () => {
+    const captureMock = vi.mocked(posthog.capture);
+
+    // given cookies are accepted and PostHog is configured and initialised
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=accepted';
+    (window as any).__posthog_initialized = true;
+
+    render(<FeedbackPage />);
+
+    // when the user types feedback into the textarea and submits the form
+    const user = userEvent.setup();
+    const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+    const feedbackText = 'This is a test feedback message.';
+
+    await user.type(feedbackTextarea, feedbackText);
+    expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
     });
 
-    it('renders warning message when cookies are not accepted', () => {
-        // given cookies are not accepted
-        document.cookie = 'moj_cookie_consent=rejected';
+    await user.click(submitButton);
 
-        // when the user is on the feedback page
-        render(<FeedbackPage />);
-
-        // then the warning message is displayed
-        expect(screen.getByText('You need to accept analytics cookies before feedback can be submitted.')).toBeInTheDocument();
+    expect(captureMock).toHaveBeenCalledWith('survey sent', {
+      $survey_response: feedbackText,
+      $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
+      $source: 'feedback-page',
     });
 
-    it('renders chatbot button', () => {
-        // when the user is on the feedback page
-        render(<FeedbackPage />);
+    // then the textarea is reset to empty
+    await waitFor(() => {
+      expect(feedbackTextarea).toHaveValue('');
+    });
+  });
 
-        // then the chatbot button is displayed
-        expect(screen.getByTestId('chatbot-button')).toBeInTheDocument();
+  test('it displays a success message after successful submission', async () => {
+    const captureMock = vi.mocked(posthog.capture);
+
+    // given cookies are accepted and PostHog is configured and initialised
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
+    document.cookie = 'moj_cookie_consent=accepted';
+    (window as any).__posthog_initialized = true;
+
+    render(<FeedbackPage />);
+
+    // when the user types feedback into the textarea and submits the form
+    const user = userEvent.setup();
+    const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
+    const feedbackText = 'This is a test feedback message.';
+
+    await user.type(feedbackTextarea, feedbackText);
+    expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
+
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
     });
 
-    it('allows users to submit feedback when cookies are accepted and PostHog is configured', async () => {
-        // given cookies are accepted and PostHog is configured
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=accepted';
+    await user.click(submitButton);
 
-        render(<FeedbackPage />);
-
-        // when the user types feedback into the textarea
-        const user = userEvent.setup();
-        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        const feedbackText = 'This is a test feedback message.';
-
-        await user.type(feedbackTextarea, feedbackText);
-        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
-
-        // then the submit button is enabled
-        await waitFor(() => {
-            expect(submitButton).toBeEnabled();
-        });
+    expect(captureMock).toHaveBeenCalledWith('survey sent', {
+      $survey_response: feedbackText,
+      $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
+      $source: 'feedback-page',
     });
 
-    it('disables submit button when feedback textarea is empty', () => {
-        // given cookies are accepted and PostHog is configured
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=accepted';
-
-        render(<FeedbackPage />);
-
-        // when the user has not typed any feedback into the textarea
-        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-        expect(feedbackTextarea).toHaveValue('');
-
-        // then the submit button is disabled
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        expect(submitButton).toBeDisabled();
+    // then the success message is displayed
+    await waitFor(() => {
+      expect(
+        screen.getByText('Thank you for your feedback. It has been submitted.'),
+      ).toBeInTheDocument();
     });
-
-    it('warning message is removed once cookies are accepted', async () => {
-        // given cookies are not accepted and the warning message is displayed
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=rejected';
-        render(<FeedbackPage />);
-        expect(screen.getByText('You need to accept analytics cookies before feedback can be submitted.')).toBeInTheDocument();
-
-        // when the user accepts cookies
-        document.cookie = 'moj_cookie_consent=accepted';
-        act(() => {
-            window.dispatchEvent(new CustomEvent('cookieConsentChange', { detail: 'accepted' }));
-        });
-
-        // then the warning message is removed
-        await waitFor(() => {
-            expect(screen.queryByText('You need to accept analytics cookies before feedback can be submitted.')).not.toBeInTheDocument();
-        });
-    });
-
-    it('calls posthog API when feedback is submitted', async () => {
-        const captureMock = vi.mocked(posthog.capture);
-
-        // given cookies are accepted and PostHog is configured and initialised
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=accepted';
-        (window as any).__posthog_initialized = true;
-
-        render(<FeedbackPage />);
-
-        // when the user types feedback into the textarea and submits the form
-        const user = userEvent.setup();
-        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        const feedbackText = 'This is a test feedback message.';
-
-        await user.type(feedbackTextarea, feedbackText);
-        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
-
-        await waitFor(() => {
-            expect(submitButton).toBeEnabled();
-        });
-
-        await user.click(submitButton);
-
-        // then the posthog API is called with the correct parameters
-        expect(captureMock).toHaveBeenCalledWith('survey sent', {
-            $survey_response: feedbackText,
-            $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
-            $source: 'feedback-page',
-        });
-    });
-
-    it('displays error message when feedback is submitted without cookies accepted', async () => {
-        const captureMock = vi.mocked(posthog.capture);
-
-        // given cookies are not accepted
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=rejected';
-
-        render(<FeedbackPage />);
-
-        // when the user types feedback into the textarea and submits the form
-        const user = userEvent.setup();
-        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        const feedbackText = 'This is a test feedback message.';
-
-        await user.type(feedbackTextarea, feedbackText);
-        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
-
-        submitButton.removeAttribute('disabled');
-
-        await user.click(submitButton);
-
-        // then the error message is displayed and the feedback is not submitted
-        expect(await screen.findByText('Please accept analytics cookies before submitting feedback.')).toBeInTheDocument();
-        expect(captureMock).not.toHaveBeenCalled();
-    });
-
-    it('displays error message when feedback is submitted without PostHog configured', async () => {
-        const captureMock = vi.mocked(posthog.capture);
-
-        // given PostHog is not configured
-        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
-        document.cookie = 'moj_cookie_consent=accepted';
-
-        render(<FeedbackPage />);
-
-        // when the user types feedback into the textarea and submits the form
-        const user = userEvent.setup();
-        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        const feedbackText = 'This is a test feedback message.';
-
-        await user.type(feedbackTextarea, feedbackText);
-        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
-        submitButton.removeAttribute('disabled');
-
-        await user.click(submitButton);
-
-        // then the error message is displayed
-        expect(await screen.findByText('Feedback could not be submitted because PostHog is not configured in this environment.')).toBeInTheDocument();
-    });
-
-    it('displays error message when feedback is submitted without PostHog initialized', async () => {
-        // given PostHog is configured but not initialised
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=accepted';
-        (window as any).__posthog_initialized = false;
-
-        render(<FeedbackPage />);
-
-        // when the user types feedback into the textarea and submits the form
-        const user = userEvent.setup();
-        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        const feedbackText = 'This is a test feedback message.';
-
-        await user.type(feedbackTextarea, feedbackText);
-        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
-        submitButton.removeAttribute('disabled');
-
-        await user.click(submitButton);
-
-        // then the error message is displayed
-        expect(await screen.findByText('Analytics is still starting. Please try again in a moment.')).toBeInTheDocument();
-    });
-
-    it('displays error message when feedback is submitted without any text', async () => {
-        // given cookies are accepted and PostHog is configured and initialised
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=accepted';
-        (window as any).__posthog_initialized = true;
-
-        render(<FeedbackPage />);
-
-        // when the user submits the form without typing any feedback
-        const user = userEvent.setup();
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-
-        submitButton.removeAttribute('disabled');
-
-        await user.click(submitButton);
-
-        // then the error message is displayed
-        expect(await screen.findByText('Please enter feedback before submitting.')).toBeInTheDocument();
-    });
-
-    it('resets textarea after successful submission', async () => {
-        const captureMock = vi.mocked(posthog.capture);
-
-        // given cookies are accepted and PostHog is configured and initialised
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=accepted';
-        (window as any).__posthog_initialized = true;
-
-        render(<FeedbackPage />);
-
-        // when the user types feedback into the textarea and submits the form
-        const user = userEvent.setup();
-        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        const feedbackText = 'This is a test feedback message.';
-
-        await user.type(feedbackTextarea, feedbackText);
-        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
-
-        await waitFor(() => {
-            expect(submitButton).toBeEnabled();
-        });
-
-        await user.click(submitButton);
-
-        expect(captureMock).toHaveBeenCalledWith('survey sent', {
-            $survey_response: feedbackText,
-            $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
-            $source: 'feedback-page',
-        });
-
-        // then the textarea is reset to empty
-        await waitFor(() => {
-            expect(feedbackTextarea).toHaveValue('');
-        });
-    });
-
-    test('it displays a success message after successful submission', async () => {
-        const captureMock = vi.mocked(posthog.capture);
-
-        // given cookies are accepted and PostHog is configured and initialised
-        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key';
-        document.cookie = 'moj_cookie_consent=accepted';
-        (window as any).__posthog_initialized = true;
-
-        render(<FeedbackPage />);
-
-        // when the user types feedback into the textarea and submits the form
-        const user = userEvent.setup();
-        const feedbackTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-        const submitButton = screen.getByRole('button', { name: 'Submit feedback' });
-        const feedbackText = 'This is a test feedback message.';
-
-        await user.type(feedbackTextarea, feedbackText);
-        expect(screen.getByRole('textbox')).toHaveValue(feedbackText);
-
-        await waitFor(() => {
-            expect(submitButton).toBeEnabled();
-        });
-
-        await user.click(submitButton);
-
-        expect(captureMock).toHaveBeenCalledWith('survey sent', {
-            $survey_response: feedbackText,
-            $survey_id: '019fd742-f2ec-0000-8f8d-4c89390a17f5',
-            $source: 'feedback-page',
-        });
-
-        // then the success message is displayed
-        await waitFor(() => {
-            expect(screen.getByText('Thank you for your feedback. It has been submitted.')).toBeInTheDocument();
-        });
-    });
+  });
 });


### PR DESCRIPTION
# Introduction :pencil2:

Partially solves [ministry-of-justice/ministry-of-justice-developer-portal#407](https://github.com/ministryofjustice/ministry-of-justice-developer-portal/issues/407) by adding a new feedback page that sends responses to Posthog for analysis. Feedback cannot be sent unless the user accepts the analytics cookies due to the Posthog integration. Submit button is disabled unless all requirements are met (cookies accepted, PostHog is configured and initialised, text written in text area).

## Resolution :heavy_check_mark:

List all changes made to the codebase.
- Created `src/app/feedback/page.tsx` providing the feedback page
- Created `tests/unit/app/feedback/Page.test.tsx` providing unit tests for the feedback page

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

<img width="1703" height="978" alt="image" src="https://github.com/user-attachments/assets/05c7d445-ef70-462f-a2e7-66d66a85f740" />

<p align="center">Feedback page</p>

<img width="1711" height="1011" alt="image" src="https://github.com/user-attachments/assets/d9f9b50e-5981-4e09-9dec-db37a7a2aeb9" />
<p align="center">Feedback page when cookies have not been accepted</p>

<img width="1696" height="1014" alt="image" src="https://github.com/user-attachments/assets/2bba1e70-c7ff-4f36-8452-5af341631198" />
<p align="center">Feedback page after feedback has been submitted</p>

<img width="1495" height="581" alt="image" src="https://github.com/user-attachments/assets/f166357d-35af-4799-94f1-c2815355492e" />
<p align="center">Posthog survey responses page</p>


</details>
